### PR TITLE
Upgrade concourse helm chart to use latest version 13.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,7 @@ resource "helm_release" "concourse" {
   namespace     = kubernetes_namespace.concourse.id
   repository    = data.helm_repository.concourse.metadata[0].name
   chart         = "concourse"
-  version       = var.concourse_chart_version
+  version       = "13.0.0"
   recreate_pods = true
 
   values = [templatefile("${path.module}/templates/values.yaml", {

--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,6 @@ resource "helm_release" "concourse" {
       "concourse.apps",
       var.concourse_hostname,
     )
-    concourse_image_tag       = var.concourse_image_tag
     basic_auth_username       = random_password.basic_auth_username.result
     basic_auth_password       = random_password.basic_auth_password.result
     github_auth_client_id     = var.github_auth_client_id

--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -7,7 +7,6 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: ${concourse_image_tag}
 
 ## Configuration values for the Concourse application (worker and web components).
 ## The values specified here are almost direct references to the flags under the

--- a/variables.tf
+++ b/variables.tf
@@ -42,11 +42,6 @@ variable "rds_instance_class" {
   description = "RDS instance class"
 }
 
-variable "concourse_chart_version" {
-  default     = "13.0.0"
-  description = "The Helm chart version"
-}
-
 variable "vpc_name" {
   default     = ""
   description = "The VPC where deployment is going to happen"

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "rds_storage" {
 }
 
 variable "rds_postgresql_version" {
-  default     = "10.6"
+  default     = "10"
   description = "Version of PostgreSQL RDS to use"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,8 @@ variable "rds_instance_class" {
   description = "RDS instance class"
 }
 
-variable "concourse_image_tag" {
-  default     = "5.8.0"
-  description = "The docker image tag to use"
-}
-
 variable "concourse_chart_version" {
-  default     = "9.0.0"
+  default     = "13.0.0"
   description = "The Helm chart version"
 }
 


### PR DESCRIPTION
Use helm chart version 13.0.0
Remove imageTag and allow helm to use the default value. Thatway we dont need to maintain seperate image and just maintain helm versions. https://github.com/concourse/concourse-chart/blob/master/values.yaml#L24

Related to: https://github.com/ministryofjustice/cloud-platform/issues/1946
