### PR TITLE
Add a 'hostname' key to the HOODAW secret

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -221,7 +221,8 @@ resource "kubernetes_secret" "hoodaw_creds" {
   }
 
   data = {
-    api_key = var.hoodaw_api_key
+    api_key  = var.hoodaw_api_key
+    hostname = var.hoodaw_host
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,11 @@ variable "sonarqube_host" {
   description = "The host of the sonarqube"
 }
 
+variable "hoodaw_host" {
+  default     = ""
+  description = "URL of the 'how-out-of-date-are-we' web application"
+}
+
 variable "hoodaw_api_key" {
   default     = ""
   description = "API key to authenticate data posts to https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
This will contain the value of `hoodaw_host`.

After merging, create a 1.5.2 release of this module.

Once this exists, pipelines will no longer need to
hard-code the URL of the web application. Instead,
they will get both the API key and the hostname
from the same secret.

This will make it easier if we move the
application to a different URL, because we will
only need to change the value in one place.

Besides, hard-coded strings are icky.

blocks https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/1025
