### PR TITLE
Allow concourse user to have full access to AWS Glue

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -108,7 +108,8 @@ data "aws_iam_policy_document" "policy" {
       "firehose:*",
       "iam:CreateServiceLinkedRole",
       "kinesis:*",
-      "athena:*"
+      "athena:*",
+      "glue:*"
     ]
 
     resources = [


### PR DESCRIPTION
 The AWS Athena  uses aws_glue service to create a data catalog