### PR TITLE
Remove version from Helm Terraform provider

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -24,7 +24,6 @@ provider "aws" {
 }
 
 provider "helm" {
-  version = "1.0.0"
   kubernetes {
   }
 }


### PR DESCRIPTION
By removing the version of the Terraform provider, tf init will automatically pull the latest version. As this is an example, it would be wise not to pin and let the user decide on the version