### PR TITLE
Create github_actions_secrets_token k8s secret

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -592,6 +592,18 @@ resource "kubernetes_secret" "concourse_main_dockerhub" {
   }
 }
 
+resource "kubernetes_secret" "github_actions_secrets_token" {
+  metadata {
+    name = "github_actions_secrets_token"
+    namespace = kubernetes_namespace.concourse_main.id
+  }
+
+  data = {
+    token = var.github_actions_secrets_token
+  }
+}
+
+
 # For ServiceMonitor
 
 resource "null_resource" "service_monitor" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,8 @@ variable "hoodaw_api_key" {
   default     = ""
   description = "API key to authenticate data posts to https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk"
 }
+
+variable "github_actions_secrets_token" {
+  default     = ""
+  description = "Github personal access token able to update any MoJ repository. Used to create github actions secrets"
+}


### PR DESCRIPTION
This change puts the value of 
`github_actions_secrets_token` into a kubernetes
secret in the concourse-main namespace, to make
it available to the environments terraform 
concourse pipelines.

depends on https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/1073