### PR TITLE
Fix the k8s secret name to github-actions-secrets-token

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -594,7 +594,7 @@ resource "kubernetes_secret" "concourse_main_dockerhub" {
 
 resource "kubernetes_secret" "github_actions_secrets_token" {
   metadata {
-    name = "github_actions_secrets_token"
+    name = "github-actions-secrets-token"
     namespace = kubernetes_namespace.concourse_main.id
   }
 


### PR DESCRIPTION
Can only have alphanumeric, - or . characters