### PR TITLE
Add TagPolicy and TagOpenIDConnectProvider permissions

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -40,6 +40,8 @@ data "aws_iam_policy_document" "policy" {
       "iam:GetPolicyVersion",
       "iam:DeleteUserPermissionsBoundary",
       "iam:TagUser",
+      "iam:TagPolicy",
+      "iam:TagOpenIDConnectProvider",
     ]
 
     resources = [

--- a/policy.tf
+++ b/policy.tf
@@ -47,7 +47,8 @@ data "aws_iam_policy_document" "policy" {
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/system/*",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/*",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cloud-platform/*"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cloud-platform/*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/oidc.eks.eu-west-2.amazonaws.com"
     ]
   }
 


### PR DESCRIPTION
The v15.6.0 terraform-aws-eks module add tagging the resources and hence concourse need permissions to set those tags when creating the cluster