### PR TITLE
Add rolebinding for concourse-web

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -435,6 +435,24 @@ resource "kubernetes_namespace" "concourse_main" {
   }
 }
 
+// Rolebinding between concourse-web serviveaccount and ClusterRole concourse-web to enable pipelines access secrets from namespace concourse-main
+resource "kubernetes_role_binding" "concourse_web" {
+  metadata {
+    name = "concourse-web-rolebinding"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "concourse-web"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "concourse-web"
+    namespace = "concourse"
+  }
+}
+
+
 resource "kubernetes_limit_range" "concourse_main" {
   metadata {
     name      = "limitrange"

--- a/main.tf
+++ b/main.tf
@@ -439,6 +439,7 @@ resource "kubernetes_namespace" "concourse_main" {
 resource "kubernetes_role_binding" "concourse_web" {
   metadata {
     name = "concourse-web-rolebinding"
+    namespace = "concourse-main"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -177,6 +177,12 @@ web:
 ## Concourse Workers, see https://concourse-ci.org/concourse-worker.html
 ##
 
+podSecurityPolicy:
+  ## Create podSecurityPolicy objects for concourse. Set this to false if
+  ## objects are not needed, or if they are managed outside helm.
+  ##
+  create: true
+
 worker:
 
   ## Number of replicas.


### PR DESCRIPTION
`concourse-web` serviceaccount was bound with the ClusterRoleBinding `concourse-build-environments`. This allowed the concourse-web pod to assume cluster-admin privileges and also assumed wrong psp.

This PR will
- add a new rolebinding for concourse-web serviceaccount to bind ClusterRole `concourse-web`. This  will allow `concourse-web` pod to  access secrets in concourse-main namespace which is needed for pipelines. 
The existing clusterrolebinding is removed in this PR: https://github.com/ministryofjustice/cloud-platform-concourse/pull/407

- create PSP needed for the concourse using the chart. 
