### PR TITLE
Moving pipelines to cloud-platform-terraform-concourse repo

### DIFF
--- a/bin/force-pipeline-state
+++ b/bin/force-pipeline-state
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+set -o errexit
+set -o pipefail
+
+_checkenv(){
+  missing=""
+  for v in URL TEAM BASIC_AUTH_USERNAME BASIC_AUTH_PASSWORD FLY_VERSION CLUSTER; do
+    vn="CONCOURSE_${v}"
+    fv=""
+    eval fv="\$$vn"
+    if [ -z "${fv}" ]; then
+      missing="${missing}\n\t${vn}"
+    fi
+  done
+  if [ ! -z "${missing}" ]; then
+    echo "missing environment variables:${missing}"
+    exit 1
+  fi
+}
+
+_tf() {
+  if [ "${#}" != 2 ]; then return 1; fi
+  if [ "${1}" != "apply" ] && [ "${1}" != "destroy" ]; then return 1; fi
+  if [ ! -d "${2}" ]; then return 0; fi
+  cd "${2}"
+  echo ">>> creating pipeline resources for $(basename ${2})"
+  (
+    set -x
+    terraform init
+    terraform "${1}" -auto-approve | sed -E 's/((content|template):[[:space:]]+)".+"/\1<REDACTED>/'
+  )
+  cd $OLDPWD
+}
+
+_checkenv
+
+apk add \
+  --no-cache \
+  --no-progress \
+  curl \
+  tar
+
+curl -Ls "https://github.com/concourse/concourse/releases/download/v${CONCOURSE_FLY_VERSION}/fly-${CONCOURSE_FLY_VERSION}-linux-amd64.tgz" | tar zxf - -C /usr/local/bin
+
+fly \
+  -t current \
+  login \
+  -k \
+  -c ${CONCOURSE_URL} \
+  -n ${CONCOURSE_TEAM} \
+  -u ${CONCOURSE_BASIC_AUTH_USERNAME} \
+  -p ${CONCOURSE_BASIC_AUTH_PASSWORD}
+
+fly -t current pipelines -a | awk '{ print $1; }' | sort > current_pipelines
+
+_team_path="pipelines/${CONCOURSE_CLUSTER}/${CONCOURSE_TEAM}"
+
+find "${_team_path}" -iname '*.yaml' -exec basename {} \; | cut -d'.' -f1 | sort > git_pipelines
+
+for i in $(comm -23 current_pipelines git_pipelines); do
+  echo ">>> deleting pipeline '${i}'"
+  (
+    set -x
+    fly \
+      -t current \
+      destroy-pipeline \
+      -n \
+      -p "${i}"
+  )
+
+  _tf destroy "${_team_path}/${i}"
+done
+
+for i in $(cat git_pipelines); do
+  _tf apply "${_team_path}/${i}"
+
+  echo ">>> setting pipeline '${i}'"
+  (
+    set -x
+    fly \
+      -t current \
+      set-pipeline \
+      -n \
+      -p "${i}" \
+      -c "${_team_path}/${i}.yaml"
+    fly \
+      -t current \
+      unpause-pipeline \
+      -p "${i}"
+  )
+done

--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -42,7 +42,7 @@ jobs:
             CONCOURSE_BASIC_AUTH_PASSWORD: ((concourse-basic-auth.password))
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache"
           inputs:
-          - name: cloud-platform-concourse
+          - name: cloud-platform-terraform-concourse
             path: ./
           run:
             path: /bin/sh

--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -1,0 +1,53 @@
+resources:
+- name: cloud-platform-terraform-concourse
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/ministryofjustice/cloud-platform-terraform-concourse
+    git_crypt_key: ((cloud-platform-concourse-git-crypt.key))
+- name: every-45m
+  type: time
+  source:
+    interval: 45m
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: "1.28"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+jobs:
+  - name: bootstrap-pipelines
+    serial: true
+    plan:
+      - aggregate:
+        - get: every-45m
+          trigger: true
+        - get: cloud-platform-terraform-concourse
+          trigger: true
+        - get: tools-image
+      - task: force-pipeline-state
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            CONCOURSE_FLY_VERSION: 6.5.1
+            CONCOURSE_URL: 'http://concourse-web.concourse.svc.cluster.local:8080'
+            CONCOURSE_TEAM: main
+            CONCOURSE_CLUSTER: manager
+            CONCOURSE_BASIC_AUTH_USERNAME: ((concourse-basic-auth.username))
+            CONCOURSE_BASIC_AUTH_PASSWORD: ((concourse-basic-auth.password))
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache"
+          inputs:
+          - name: cloud-platform-concourse
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                ./bin/force-pipeline-state

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -1,0 +1,119 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: main
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: "1.43"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+slack_failure_notification: &slack_failure_notification
+  put: slack-alert
+  params:
+    <<: *SLACK_NOTIFICATION_DEFAULTS
+    attachments:
+      - color: "danger"
+        <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+common_params: &common_params
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+  KOPS_STATE_STORE: s3://cloud-platform-kops-state
+  KUBE_CONFIG_PATH: ~/.kube/config
+
+groups:
+- name: cluster-test
+  jobs:
+    - build-kops-test-cluster
+    - build-eks-test-cluster
+
+jobs:
+  - name: build-kops-test-cluster
+    serial: true
+    plan:
+      - in_parallel:
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false
+      - task: build-kops-test-cluster
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-(
+                export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
+                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
+                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
+        on_failure: *slack_failure_notification
+
+  - name: build-eks-test-cluster
+    serial: true
+    plan:
+      - in_parallel:
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false
+      - task: build-eks-test-cluster
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params            
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-(
+                export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
+                echo "Executing: ./create-cluster.rb --kind eks --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
+                ./create-cluster.rb --kind eks --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
+        on_failure: *slack_failure_notification

--- a/pipelines/manager/main/cloud-platform-infrastructure.yaml
+++ b/pipelines/manager/main/cloud-platform-infrastructure.yaml
@@ -1,0 +1,123 @@
+resource_types:
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+
+resources:
+- name: cloud-platform-cli
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-cli
+    tag: "1.9.8"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: pull-request
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: ministryofjustice/cloud-platform-infrastructure
+    access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: merged-pull-request
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: ministryofjustice/cloud-platform-infrastructure
+    access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+    states: [ "MERGED" ]
+
+
+groups:
+- name: cp-infra-terraform-automation
+  jobs:
+    - plan-cloud-platform-infrastructure
+    - apply-cloud-platform-infrastructure
+
+jobs:
+  - name: plan-cloud-platform-infrastructure
+    serial: true
+    plan:
+    - get: cloud-platform-cli
+    - get: pull-request
+      trigger: true
+      version: every
+    - put: pull-request
+      params:
+        path: pull-request
+        status: pending
+      get_params: {list_changed_files: true}
+    - task: execute-terraform-plan
+      image: cloud-platform-cli
+      config:
+        platform: linux
+        params:
+          AWS_ACCESS_KEY_ID: ((cloud-platform-admin-user-creds.access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((cloud-platform-admin-user-creds.secret-access-key))
+          AWS_REGION: eu-west-2
+          KUBECONFIG: /tmp/kubeconfig
+          KUBE_CONFIG_PATH: /tmp/kubeconfig
+          AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+          AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+          AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+        inputs:
+        - name: pull-request
+        run:
+          path: /bin/sh
+          dir: pull-request
+          args:
+            - -c
+            - |
+              (
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
+              )
+              cloud-platform terraform plan --dirs-file .git/resource/changed_files --skip-version-check
+      on_failure:
+        put: pull-request
+        params:
+          path: pull-request
+          status: failure
+    - put: pull-request
+      params:
+        path: pull-request
+        status: success
+  - name: apply-cloud-platform-infrastructure
+    serial: true
+    plan:
+    - get: cloud-platform-cli
+    - get: merged-pull-request
+      trigger: true
+      version: every
+    - put: merged-pull-request
+      params:
+        path: merged-pull-request
+      get_params: {list_changed_files: true}
+    - task: execute-terraform-apply
+      image: cloud-platform-cli
+      config:
+        platform: linux
+        params:
+          AWS_ACCESS_KEY_ID: ((cloud-platform-admin-user-creds.access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((cloud-platform-admin-user-creds.secret-access-key))
+          AWS_REGION: eu-west-2
+          KUBECONFIG: /tmp/kubeconfig
+          KUBE_CONFIG_PATH: /tmp/kubeconfig
+          AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+          AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+          AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+        inputs:
+        - name: merged-pull-request
+        run:
+          path: /bin/sh
+          dir: merged-pull-request
+          args:
+            - -c
+            - |
+              (
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                kubectl config use-context live-1.cloud-platform.service.justice.gov.uk
+              )
+              cloud-platform terraform apply --dirs-file .git/resource/changed_files --skip-version-check
+

--- a/pipelines/manager/main/create-test-destroy.yaml
+++ b/pipelines/manager/main/create-test-destroy.yaml
@@ -1,0 +1,151 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: main
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: "1.43"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: keyval
+  type: keyval
+- name: after-midnight
+  type: time
+  source:
+    start: 1:00 AM
+    stop: 3:00 AM
+    location: Europe/London
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+- name: keyval
+  type: docker-image
+  source:
+    repository: swce/keyval-resource
+
+
+slack_failure_notification: &slack_failure_notification
+  put: slack-alert
+  params:
+    <<: *SLACK_NOTIFICATION_DEFAULTS
+    attachments:
+      - color: "danger"
+        <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+common_params: &common_params
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+  KOPS_STATE_STORE: s3://cloud-platform-kops-state
+  KUBE_CONFIG_PATH: ~/.kube/config
+
+jobs:
+  - name: create-cluster-run-tests
+    serial: true
+    plan:
+      - in_parallel:
+        - get: after-midnight
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false
+      - task: create-cluster-run-integration
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          outputs:
+          - name: keyval
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                export CLUSTER_NAME=xx-$(date +%d%m-%H%M)
+                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 1200"
+                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 1200
+
+                #  Output the integration-test results
+                cat ./smoke-tests/${CLUSTER_NAME}-rspec.txt
+
+                #  keyval/keyval.properties file, will pass on the cluster name info to the next job destroy-cluster
+                echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
+        on_failure: *slack_failure_notification
+      - put: keyval
+        params:
+          file: keyval/keyval.properties
+
+  - name: destroy-cluster
+    serial: true
+    plan:
+      - in_parallel:
+        - get: after-midnight
+          trigger: false
+          passed:
+          - create-cluster-run-tests
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: tools-image
+          trigger: false
+        - get: keyval
+          trigger: true
+          passed:
+          - create-cluster-run-tests
+      - task: destroy-test-cluster
+        image: tools-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          - name: keyval
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                #  This will export cluster name info from the previous job create-cluster-run-tests
+                export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
+
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                echo "Executing: ./destroy-cluster.rb -n $CLUSTER_NAME"
+                ./destroy-cluster.rb --name $CLUSTER_NAME --yes
+        on_failure: *slack_failure_notification

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -1,0 +1,267 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: main
+    git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+- name: cloud-platform-cli
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-cli
+    tag: "1.9.8"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-4-hours
+  type: time
+  source:
+    interval: 4h
+
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+groups:
+- name: divergence
+  jobs:
+    - divergence-kops
+    - divergence-eks
+    - divergence-eks-components
+    - divergence-networking
+    - divergence-kops-components
+
+
+jobs:
+  - name: divergence-eks
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-4-hours
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: cloud-platform-cli
+          trigger: false
+      - task: check-divergence-eks
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+            AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+            AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                cd terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                cloud-platform terraform check-divergence --workspace manager --skip-version-check
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+  - name: divergence-eks-components
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-4-hours
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: cloud-platform-cli
+          trigger: false
+      - task: check-divergence-eks-components
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            KUBE_CLUSTER: manager.cloud-platform.service.justice.gov.uk
+            KUBE_CTX: manager.cloud-platform.service.justice.gov.uk
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                  kubectl config use-context ${KUBE_CLUSTER}
+                )
+                cd terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                cloud-platform terraform check-divergence --workspace manager --skip-version-check
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+  - name: divergence-kops
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-4-hours
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: cloud-platform-cli
+          trigger: false
+      - task: check-divergence-kops
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+            AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+            AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                cd terraform/aws-accounts/cloud-platform-aws/vpc/kops
+                cloud-platform terraform check-divergence --workspace live-1 --skip-version-check
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+  - name: divergence-networking
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-4-hours
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: cloud-platform-cli
+          trigger: false
+      - task: check-divergence-networking
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                cd terraform/aws-accounts/cloud-platform-aws/vpc
+                cloud-platform terraform check-divergence --workspace live-1 --skip-version-check
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+  - name: divergence-kops-components
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-4-hours
+          trigger: true
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+        - get: cloud-platform-cli
+          trigger: false
+      - task: check-divergence-kops-components
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          inputs:
+          - name: cloud-platform-infrastructure-repo
+            path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                cd terraform/aws-accounts/cloud-platform-aws/vpc/kops/components
+                cloud-platform terraform check-divergence --workspace live-1 --skip-version-check
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -1,0 +1,243 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: main
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: cloud-platform-environments-live-pull-requests
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: ministryofjustice/cloud-platform-environments
+    access_token: ((cloud-platform-environments-pr-git-access-token))
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+    paths:
+    - namespaces/live.cloud-platform.service.justice.gov.uk
+- name: pipeline-tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-pipeline-tools
+    tag: "1.43"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-120m
+  type: time
+  source:
+    interval: 120m
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+
+groups:
+- name: environments-terraform
+  jobs:
+    - apply-live
+    - apply-namespace-changes-live
+    - plan-live
+
+jobs:
+  - name: apply-live
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-120m
+          trigger: true
+        - get: cloud-platform-environments-repo
+          trigger: false
+        - get: pipeline-tools-image
+      - task: apply-environments
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+            # the variable cluster_name here is used to get VPC info
+            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                bundle install --without development test
+                ./bin/apply
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: apply-namespace-changes-live
+    serial: false
+    plan:
+      - in_parallel:
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: pipeline-tools-image
+      - task: apply-namespace-changes
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+            # the variable cluster_name here is used to get VPC info
+            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                bundle install --without development test
+                ./bin/apply-namespace-changes
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: plan-live
+    serial: true
+    plan:
+      - get: cloud-platform-environments-live-pull-requests
+        trigger: true
+        version: every
+      - put: cloud-platform-environments-live-pull-requests
+        params:
+          path: cloud-platform-environments-live-pull-requests
+          status: pending
+      - get: pipeline-tools-image
+      - task: plan-environments
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-live-pull-requests
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            # the variables prefixed with PIPELINE_ are used by the plan script
+            PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            # the variable cluster_name here is used to get VPC info
+            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-live-pull-requests
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                export branch_head_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "head_sha") | .value')
+                export main_base_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "base_sha") | .value')
+                bundle install --without development test
+                ./bin/plan
+        on_failure:
+            put: cloud-platform-environments-live-pull-requests
+            params:
+              path: cloud-platform-environments-live-pull-requests
+              status: failure
+        on_success:
+            put: cloud-platform-environments-live-pull-requests
+            params:
+              path: cloud-platform-environments-live-pull-requests
+              status: success

--- a/pipelines/manager/main/environments-terraform.yaml
+++ b/pipelines/manager/main/environments-terraform.yaml
@@ -1,0 +1,241 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: main
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: cloud-platform-environments-live-1-pull-requests
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: ministryofjustice/cloud-platform-environments
+    access_token: ((cloud-platform-environments-pr-git-access-token))
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+    paths:
+    - namespaces/live-1.cloud-platform.service.justice.gov.uk
+- name: pipeline-tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-pipeline-tools
+    tag: "1.43"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-120m
+  type: time
+  source:
+    interval: 120m
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+
+groups:
+- name: environments-terraform
+  jobs:
+    - apply-live-1
+    - apply-namespace-changes-live-1
+    - plan-live-1
+
+jobs:
+  - name: apply-live-1
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-120m
+          trigger: true
+        - get: cloud-platform-environments-repo
+          trigger: false
+        - get: pipeline-tools-image
+      - task: apply-environments
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                bundle install --without development test
+                ./bin/apply
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: apply-namespace-changes-live-1
+    serial: false
+    plan:
+      - in_parallel:
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: pipeline-tools-image
+      - task: apply-namespace-changes
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                bundle install --without development test
+                ./bin/apply-namespace-changes
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: plan-live-1
+    serial: true
+    plan:
+      - get: cloud-platform-environments-live-1-pull-requests
+        trigger: true
+        version: every
+      - put: cloud-platform-environments-live-1-pull-requests
+        params:
+          path: cloud-platform-environments-live-1-pull-requests
+          status: pending
+      - get: pipeline-tools-image
+      - task: plan-environments
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-live-1-pull-requests
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            # the variables prefixed with PIPELINE_ are used by the plan script
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_cluster_name: "live-1"
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+            TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-live-1-pull-requests
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                )
+                export branch_head_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "head_sha") | .value')
+                export main_base_sha=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name == "base_sha") | .value')
+                bundle install --without development test
+                ./bin/plan
+        on_failure:
+            put: cloud-platform-environments-live-1-pull-requests
+            params:
+              path: cloud-platform-environments-live-1-pull-requests
+              status: failure
+        on_success:
+            put: cloud-platform-environments-live-1-pull-requests
+            params:
+              path: cloud-platform-environments-live-1-pull-requests
+              status: success
+

--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -1,0 +1,80 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+  silent: true
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: dashboard-reporter-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
+    tag: "3.7"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+
+- name: every-24h-during-workweek
+  type: time
+  source:
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+    interval: 24h
+    start: 10:00 AM
+    stop: 5:00 PM
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+groups:
+- name: hoodaw
+  jobs:
+    - hoodaw-dashboard-reporter
+
+jobs:
+  - name: hoodaw-dashboard-reporter
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-24h-during-workweek
+          trigger: true
+        - get: dashboard-reporter-image
+      - task: generate-report
+        image: dashboard-reporter-image
+        config:
+          platform: linux
+          outputs:
+            - name: report
+          params:
+            DASHBOARD_URL: ((cloud-platform-reports-api-key.hostname))/dashboard
+            OUTPUT_FILE: report/action_items
+          run:
+            path: /app/report.rb
+        on_success:
+          put: slack-alert
+          params:
+            channel: '#cloud-platform'
+            text_file: report/action_items
+            attachments:
+              - color: "warning"
+                title: 'How out of date are we - action required:'
+                title_link: ((cloud-platform-reports-api-key.hostname))/dashboard
+                footer: ((cloud-platform-reports-api-key.hostname))
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -1,0 +1,263 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: main
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: main
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: cloud-platform-terraform-bastion-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-terraform-bastion.git
+    branch: main
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: "1.43"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-1h-during-workdays
+  type: time
+  source:
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+    interval: 1h
+    start: 8:00 AM
+    stop: 5:00 PM
+- name: every-1h-between-midnight-3am
+  type: time
+  source:
+    interval: 1h
+    start: 00:00 AM
+    stop: 03:00 AM
+- name: every-day
+  type: time
+  source:
+    interval: 24h
+- name: every-30m
+  type: time
+  source:
+    interval: 30m
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+groups:
+- name: maintenance
+  jobs:
+    - recycle-node-live-1
+    - delete-manually-created-pods-live-1
+    - delete-excess-dns
+    - update-authorized-keys
+    - delete-completed-jobs
+
+jobs:
+  - name: recycle-node-live-1
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-1h-between-midnight-3am
+          trigger: true
+        - get: tools-image
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+      - task: recycle-oldest-node-live-1
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            K8S_CLUSTER_NAME: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-infrastructure-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${K8S_CLUSTER_NAME}
+                ./recycle-node.rb
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: delete-manually-created-pods-live-1
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-day
+          trigger: true
+        - get: cloud-platform-environments-repo
+        - get: tools-image
+      - task: run-script
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                bundle install --without development test
+                ./bin/delete_manually_created_pods.rb
+
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: delete-excess-dns
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-day
+          trigger: true
+        - get: tools-image
+        - get: cloud-platform-environments-repo
+      - task: run-script
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBECONFIG: /tmp/kubeconfig
+            K8S_CLUSTER_NAME: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${K8S_CLUSTER_NAME}
+                ./bin/delete_unused_dns_records.rb
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: update-authorized-keys
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-1h-during-workdays
+          trigger: true
+        - get: tools-image
+        - get: cloud-platform-terraform-bastion-repo
+      - task: run-script 
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-terraform-bastion-repo
+          params:
+            GITHUB_TOKEN: ((authorized-keys-github-token.token)) 
+          run:
+            path: /bin/sh
+            dir: cloud-platform-terraform-bastion-repo
+            args:
+              - -c
+              - |
+                ./bin/update-authorized-keys.rb
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: delete-completed-jobs
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-30m
+          trigger: true
+        - get: cloud-platform-environments-repo
+        - get: tools-image
+      - task: run-script-delete-completed-jobs
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                bundle install --without development test
+                ./bin/delete_completed_jobs.rb
+
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -1,0 +1,340 @@
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: '#lower-priority-alarms'
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  footer: concourse.cloud-platform.service.justice.gov.uk/
+
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+  KUBECONFIG_S3_KEY: kubeconfig
+  KUBECONFIG: /tmp/kubeconfig
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+resources:
+- name: cloud-platform-infrastructure-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+    branch: main
+- name: integration-test-image
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
+    tag: "1.7"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: e2e-test-image
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tests
+    tag: "0.7"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: orphaned-namespace-checker-image
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
+    tag: "2.25"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: cloud-platform-tools-terraform
+  type: docker-image
+  source:
+    repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tools-terraform
+    tag: "0.3"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-hour
+  type: time
+  source:
+    interval: 60m
+- name: every-12-hours
+  type: time
+  source:
+    interval: 12h
+- name: every-24-hours
+  type: time
+  source:
+    interval: 24h
+- name: every-6-hours
+  type: time
+  source:
+    interval: 6h
+
+groups:
+- name: reporting
+  jobs:
+    - orphaned-namespaces
+    - integration-tests
+    - live-integration-tests-golang
+    - live-integration-tests-rspec
+    - eks-integration-tests
+    - manual-snapshots-checker
+
+jobs:
+  - name: orphaned-namespaces
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-24-hours
+          trigger: true
+        - get: orphaned-namespace-checker-image
+      - task: check-environments
+        image: orphaned-namespace-checker-image
+        config:
+          platform: linux
+          params:
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG_AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
+            KUBE_CONFIG: /tmp/kubeconfig
+            KUBERNETES_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            TFSTATE_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            TFSTATE_AWS_REGION: eu-west-1
+            TFSTATE_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            TFSTATE_BUCKET: cloud-platform-terraform-state
+            TFSTATE_BUCKET_PREFIX: cloud-platform-environments/live-1.cloud-platform.service.justice.gov.uk
+            GITHUB_TOKEN: ((cloud-platform-environments-pr-git-access-token))
+          run:
+            user: root
+            path: /app/bin/orphaned_namespaces.rb
+          outputs:
+            - name: output
+        on_success:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            text_file: output/check.txt
+        on_failure:
+            put: slack-alert
+            params:
+              <<: *SLACK_NOTIFICATION_DEFAULTS
+              attachments:
+                - color: "danger"
+                  <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: integration-tests
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-hour
+          trigger: true
+        - get: integration-test-image
+          trigger: false
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+      - task: test-live-1
+        image: integration-test-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+          params:
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            KUBE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            EXECUTION_CONTEXT: integration-test-pipeline
+          run:
+            path: /bin/sh
+            dir: cloud-platform-infrastructure-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                cd ./smoke-tests; rspec --tag ~cluster:test-cluster-only --tag ~eks-manager
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+  
+  - name: live-integration-tests-rspec
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-hour
+          trigger: true
+        - get: integration-test-image
+          trigger: false
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+      - task: test-live-1
+        image: integration-test-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+          params:
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            KUBE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+            EXECUTION_CONTEXT: integration-test-pipeline
+          run:
+            path: /bin/sh
+            dir: cloud-platform-infrastructure-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                cd ./smoke-tests; rspec --tag ~cluster:test-cluster-only --tag ~live-1 --tag ~kops --tag ~concourse-test
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: live-integration-tests-golang
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-hour
+          trigger: true
+        - get: e2e-test-image
+          trigger: false
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+      - task: test-live-1
+        image: e2e-test-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+          params:
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            KUBE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+            EXECUTION_CONTEXT: integration-test-pipeline
+          run:
+            path: /bin/sh
+            dir: cloud-platform-infrastructure-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                cd ./tests/e2e; e2e-tests -test.v -ginkgo.slowSpecThreshold=120 -config ../config/live.yaml
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: eks-integration-tests
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-6-hours
+          trigger: true
+        - get: integration-test-image
+          trigger: false
+        - get: cloud-platform-infrastructure-repo
+          trigger: false
+      - task: test-eks
+        image: integration-test-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+          params:
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            KUBE_CLUSTER: manager.cloud-platform.service.justice.gov.uk
+            EXECUTION_CONTEXT: integration-test-pipeline
+          run:
+            path: /bin/sh
+            dir: cloud-platform-infrastructure-repo
+            args:
+              - -c
+              - |
+                aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+                kubectl config use-context ${KUBE_CLUSTER}
+                cd ./smoke-tests; rspec --tag ~cluster:test-cluster-only --tag ~live-1 --tag ~kops
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: manual-snapshots-checker
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-12-hours
+          trigger: true
+        - get: cloud-platform-tools-terraform
+          trigger: false
+      - task: manual-snapshots-checker
+        image: cloud-platform-tools-terraform
+        config:
+          platform: linux
+          params:
+            <<: *AWS_CREDENTIALS
+            ALERT_WHEN_SNAPSHOTS_PERCENT_GT: 70
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                RdsLimits=( $(aws rds describe-account-attributes --region ${AWS_REGION} --query 'AccountQuotas[?starts_with(AccountQuotaName, `ManualSnapshots`) == `true`]|[].[Used,Max]' --output text | awk '{print $1, $2}') )
+
+                AlertOn=$(( (${RdsLimits[1]} * ${ALERT_WHEN_SNAPSHOTS_PERCENT_GT}) / 100 ))
+
+                echo "Snapshot number: ${RdsLimits[0]}            Snapshot limit: ${RdsLimits[1]}"
+                echo "Alerting if snapshots are more than ${AlertOn} (${ALERT_WHEN_SNAPSHOTS_PERCENT_GT}% of the limit)"
+
+                if [ ${RdsLimits[0]} -ge ${AlertOn} ]; then
+                   echo "Ups, number of snapshots (${RdsLimits[0]}) are more than ${ALERT_WHEN_SNAPSHOTS_PERCENT_GT}% (${AlertOn}) of the limits ( ${RdsLimits[1]} ). Please cleanup"
+                   exit 1
+                else
+                   echo "Happy life! Snapshots are fine :-)"
+                   exit 0
+                fi
+          outputs:
+            - name: metadata
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/scanning.yaml
+++ b/pipelines/manager/main/scanning.yaml
@@ -1,0 +1,59 @@
+resources:
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: main
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-sonar-scanner-cli
+    tag: 1.1
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+- name: every-12-hours
+  type: time
+  source:
+    interval: 12h
+  
+groups:
+- name: environments-terraform
+  jobs:
+    - sonar-scan-all-repos
+
+jobs:
+  - name: sonar-scan-all-repos
+    serial: true
+    plan:
+      - in_parallel:
+        - get: cloud-platform-environments-repo
+          trigger: false
+        - get: every-12-hours
+          trigger: true
+        - get: tools-image
+      - task: sonar-scan-all-repos
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            KUBECONFIG: /tmp/kubeconfig
+            PIPELINE_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            SONARQUBE_TOKEN: ((sonarqube-creds.token))
+            SONARQUBE_HOST_URL: ((sonarqube-creds.host))
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |-
+                aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                bundle install --without development test
+                chmod +x ./bin/sq_scan_all_repos.rb
+                ./bin/sq_scan_all_repos.rb


### PR DESCRIPTION
As discussed in https://github.com/ministryofjustice/cloud-platform/issues/3017 we are pipelines within the terraform module repo.

Still pending to integrate the terraform files to build the kubeconfigs