### PR TITLE
Update create-test-destroy to run on weekdays

### DIFF
--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -36,6 +36,7 @@ resources:
 - name: after-midnight
   type: time
   source:
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
     start: 1:00 AM
     stop: 3:00 AM
     location: Europe/London

--- a/pipelines/manager/main/kops-create-test-destroy.yaml
+++ b/pipelines/manager/main/kops-create-test-destroy.yaml
@@ -29,6 +29,7 @@ resources:
 - name: after-midnight
   type: time
   source:
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
     start: 1:00 AM
     stop: 3:00 AM
     location: Europe/London


### PR DESCRIPTION
This is to avoid leftover clusters over the weekend when tests fail. Also, we won't be pushing changes to the infra repo during the weekend, so this is not needed over the weekend.