### PR TITLE
Increase resource limit to 8gi

### DIFF
--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -189,7 +189,7 @@ worker:
       memory: "1Gi"
     limits:
       cpu: "2000m"
-      memory: "4Gi"
+      memory: "8Gi"
 
 
 ## Persistent Volume Storage configuration.


### PR DESCRIPTION
This is to fix "ProcessNotFoundError",
suggestion below to tune resource values:
https://github.com/concourse/concourse/wiki/Error-Messages-And-What-To-Do-About-Them#processnotfounderror