### PR TITLE
Rename ambigious pipeline names

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -67,14 +67,14 @@ resource_types:
 groups:
 - name: maintenance
   jobs:
-    - recycle-node-live-1
-    - delete-manually-created-pods-live-1
-    - delete-excess-dns
-    - update-authorized-keys
-    - delete-completed-jobs
+    - live-1-recycle-node
+    - live-1-delete-manually-created-pods
+    - aws-delete-excess-dns
+    - github-update-authorized-keys
+    - live-1-delete-completed-jobs
 
 jobs:
-  - name: recycle-node-live-1
+  - name: live-1-recycle-node
     serial: true
     plan:
       - in_parallel:
@@ -83,7 +83,7 @@ jobs:
         - get: tools-image
         - get: cloud-platform-infrastructure-repo
           trigger: false
-      - task: recycle-oldest-node-live-1
+      - task: recycle-oldest-node
         image: tools-image
         config:
           platform: linux
@@ -116,7 +116,7 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: delete-manually-created-pods-live-1
+  - name: live-1-delete-manually-created-pods
     serial: true
     plan:
       - in_parallel:
@@ -153,7 +153,7 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: delete-excess-dns
+  - name: aws-delete-excess-dns
     serial: true
     plan:
       - in_parallel:
@@ -194,7 +194,7 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: update-authorized-keys
+  - name: github-update-authorized-keys
     serial: true
     plan:
       - in_parallel:
@@ -202,14 +202,14 @@ jobs:
           trigger: true
         - get: tools-image
         - get: cloud-platform-terraform-bastion-repo
-      - task: run-script 
+      - task: run-script
         image: tools-image
         config:
           platform: linux
           inputs:
             - name: cloud-platform-terraform-bastion-repo
           params:
-            GITHUB_TOKEN: ((authorized-keys-github-token.token)) 
+            GITHUB_TOKEN: ((authorized-keys-github-token.token))
           run:
             path: /bin/sh
             dir: cloud-platform-terraform-bastion-repo
@@ -225,7 +225,7 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: delete-completed-jobs
+  - name: live-1-delete-completed-jobs
     serial: true
     plan:
       - in_parallel:

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -31,7 +31,7 @@ resources:
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
     branch: main
-- name: rpsec-integration-test-image
+- name: rspec-integration-test-image
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
@@ -142,7 +142,7 @@ jobs:
         - get: cloud-platform-infrastructure-repo
           trigger: false
       - task: run-rspec-tests
-        image: rpsec-integration-test-image
+        image: rspec-integration-test-image
         config:
           platform: linux
           inputs:

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -31,14 +31,14 @@ resources:
   source:
     uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
     branch: main
-- name: integration-test-image
+- name: rpsec-integration-test-image
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
     tag: "1.7"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: e2e-test-image
+- name: go-integration-test-image
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/cloud-platform-tests
@@ -79,22 +79,22 @@ resources:
 groups:
 - name: reporting
   jobs:
-    - orphaned-namespaces
-    - integration-tests
-    - live-integration-tests-golang
+    - live-1-orphaned-namespaces
+    - live-1-integration-tests-rspec
+    - live-integration-tests-go
     - live-integration-tests-rspec
-    - eks-integration-tests
-    - manual-snapshots-checker
+    - manager-integration-tests-go
+    - rds-manual-snapshots-checker
 
 jobs:
-  - name: orphaned-namespaces
+  - name: live-1-orphaned-namespaces
     serial: true
     plan:
       - in_parallel:
         - get: every-24-hours
           trigger: true
         - get: orphaned-namespace-checker-image
-      - task: check-environments
+      - task: check-orphaned-namespaces
         image: orphaned-namespace-checker-image
         config:
           platform: linux
@@ -131,18 +131,18 @@ jobs:
                 - color: "danger"
                   <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: integration-tests
+  - name: live-1-integration-tests-rspec
     serial: true
     plan:
       - in_parallel:
         - get: every-hour
           trigger: true
-        - get: integration-test-image
+        - get: rspec-integration-test-image
           trigger: false
         - get: cloud-platform-infrastructure-repo
           trigger: false
-      - task: test-live-1
-        image: integration-test-image
+      - task: run-rspec-tests
+        image: rpsec-integration-test-image
         config:
           platform: linux
           inputs:
@@ -170,19 +170,19 @@ jobs:
             attachments:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
-  
+
   - name: live-integration-tests-rspec
     serial: true
     plan:
       - in_parallel:
         - get: every-hour
           trigger: true
-        - get: integration-test-image
+        - get: rspec-integration-test-image
           trigger: false
         - get: cloud-platform-infrastructure-repo
           trigger: false
-      - task: test-live
-        image: integration-test-image
+      - task: run-rspec-tests
+        image: rspec-integration-test-image
         config:
           platform: linux
           inputs:
@@ -211,18 +211,18 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: live-integration-tests-golang
+  - name: live-integration-tests-go
     serial: true
     plan:
       - in_parallel:
         - get: every-hour
           trigger: true
-        - get: e2e-test-image
+        - get: go-integration-test-image
           trigger: false
         - get: cloud-platform-infrastructure-repo
           trigger: false
-      - task: test-live
-        image: e2e-test-image
+      - task: run-go-tests
+        image: go-integration-test-image
         config:
           platform: linux
           inputs:
@@ -251,18 +251,18 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: eks-integration-tests
+  - name: manager-integration-tests-rspec
     serial: true
     plan:
       - in_parallel:
         - get: every-6-hours
           trigger: true
-        - get: integration-test-image
+        - get: rspec-integration-test-image
           trigger: false
         - get: cloud-platform-infrastructure-repo
           trigger: false
-      - task: test-eks
-        image: integration-test-image
+      - task: run-rspec-tests
+        image: rspec-integration-test-image
         config:
           platform: linux
           inputs:
@@ -291,7 +291,7 @@ jobs:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
 
-  - name: manual-snapshots-checker
+  - name: rds-manual-snapshots-checker
     serial: true
     plan:
       - in_parallel:


### PR DESCRIPTION
Connected to https://github.com/ministryofjustice/cloud-platform/issues/3294

To get a better idea of which pipelines run against which clusters, I felt we could first uniform the pipeline naming in reports and maintenance. This should give us a better idea of what's missing in "live".