### PR TITLE
Remove KUBE_CONFIG_PATH env var

### DIFF
--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -72,7 +72,6 @@ common_params: &common_params
   AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
   AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
   KOPS_STATE_STORE: s3://cloud-platform-kops-state
-  KUBE_CONFIG_PATH: ~/.kube/config
 
 jobs:
   - name: create-cluster-eks


### PR DESCRIPTION
After upgrading to the new k8's provider, we don't have the option to set load_config to false,
so need to remove the config path to use the K8s provider