### PR TITLE
Create new job for live-orphaned-namespaces

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -49,7 +49,7 @@ resources:
   type: docker-image
   source:
     repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-    tag: "2.26"
+    tag: "2.27"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-tools-terraform
@@ -80,6 +80,7 @@ groups:
 - name: reporting
   jobs:
     - live-1-orphaned-namespaces
+    - live-orphaned-namespaces
     - live-1-integration-tests-rspec
     - live-integration-tests
     - manager-integration-tests-rspec
@@ -114,6 +115,44 @@ jobs:
             KUBE_CTX: live-1.cloud-platform.service.justice.gov.uk
             KUBE_CONFIG: /tmp/kubeconfig
             KUBERNETES_CLUSTER: live-1.cloud-platform.service.justice.gov.uk
+            TFSTATE_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            TFSTATE_AWS_REGION: eu-west-1
+            TFSTATE_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            TFSTATE_BUCKET: cloud-platform-terraform-state
+            TFSTATE_BUCKET_PREFIX: cloud-platform-environments/live-1.cloud-platform.service.justice.gov.uk
+            GITHUB_TOKEN: ((cloud-platform-environments-pr-git-access-token))
+          run:
+            user: root
+            path: /app/bin/orphaned_namespaces.rb
+          outputs:
+            - name: output
+        on_success:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            text_file: output/check.txt
+        on_failure: *slack_failure_notification
+
+  - name: live-orphaned-namespaces
+    serial: true
+    plan:
+      - in_parallel:
+        - get: every-24-hours
+          trigger: true
+        - get: orphaned-namespace-checker-image
+      - task: check-orphaned-namespaces
+        image: orphaned-namespace-checker-image
+        config:
+          platform: linux
+          params:
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG_AWS_REGION: eu-west-2
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBE_CTX: live.cloud-platform.service.justice.gov.uk
+            KUBE_CONFIG: /tmp/kubeconfig
+            KUBERNETES_CLUSTER: live.cloud-platform.service.justice.gov.uk
             TFSTATE_AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
             TFSTATE_AWS_REGION: eu-west-1
             TFSTATE_AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))


### PR DESCRIPTION
This job runs the script to compare the namespaces, which exist in the cluster to those which are defined in the env-repo.
 https://github.com/ministryofjustice/cloud-platform-environments-checker/blob/main/bin/orphaned_namespaces.rb