### PR TITLE
Add timeout for apply and plan pipeline

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -74,6 +74,7 @@ jobs:
           trigger: false
         - get: pipeline-tools-image
       - task: apply-environments
+        timeout: 4h
         image: pipeline-tools-image
         config:
           platform: linux
@@ -130,6 +131,7 @@ jobs:
           trigger: true
         - get: pipeline-tools-image
       - task: apply-namespace-changes
+        timeout: 1h
         image: pipeline-tools-image
         config:
           platform: linux
@@ -190,6 +192,7 @@ jobs:
           status: pending
       - get: pipeline-tools-image
       - task: plan-environments
+        timeout: 1h
         image: pipeline-tools-image
         config:
           platform: linux


### PR DESCRIPTION
This is to limit the step's execution.

This run waiting for the below input and stuck for a couple of days without any error, this timeout should fix that issue in future runs
Username for 'https://github.com':

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-live/builds/1242


