### PR TITLE
Enable auto namespace deletion for live

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -62,6 +62,7 @@ groups:
     - apply-namespace-changes-live
     - plan-live
     - detect-deleted-namespaces
+    - destroy-deleted-namespaces
 
 jobs:
   - name: apply-live
@@ -273,7 +274,6 @@ jobs:
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
-            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
           run:
@@ -284,6 +284,57 @@ jobs:
               - |
                 bundle install --without development test
                 ./bin/deleted-namespaces.rb
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS
+
+  - name: destroy-deleted-namespaces
+    serial: true
+    plan:
+      - in_parallel:
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: pipeline-tools-image
+      - task: destroy-deleted-namespaces
+        image: pipeline-tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: cloud-platform-environments-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBE_CONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            KUBE_CTX: live.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            SLACK_WEBHOOK: ((slack-hook-id))
+            PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            # the variable cluster_name provided here as required when running terraform init
+            TF_VAR_cluster_name: concourse.cloud-platform.service.justice.gov.uk
+            TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
+            TF_VAR_github_owner: "ministryofjustice"
+            TF_VAR_github_token: ((github-actions-secrets-token.token))
+            # the variable TF_VAR_kubernetes_cluster provided here as required when running terraform init
+            TF_VAR_kubernetes_cluster: " concourse.cloud-platform.service.justice.gov.uk"
+          run:
+            path: /bin/sh
+            dir: cloud-platform-environments-repo
+            args:
+              - -c
+              - |
+                bundle install --without development test
+                ./bin/auto-delete-namespace.rb
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
This pipeline will delete the namespace, deleted in the PR

We disabled it during live-1 to live migration, enabling it back as migration is now completed