### PR TITLE
Bump cli image to 1.14.10

### DIFF
--- a/pipelines/manager/main/cloud-platform-infrastructure.yaml
+++ b/pipelines/manager/main/cloud-platform-infrastructure.yaml
@@ -24,7 +24,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.14.8"
+    tag: "1.14.10"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: pull-request

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.14.8"
+    tag: "1.14.10"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: slack-alert


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-cli/pull/174

This has the aws cli version 2.7.6.