### PR TITLE
Remove the paths option from live environments pipeline

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -21,8 +21,6 @@ resources:
     repository: ministryofjustice/cloud-platform-environments
     access_token: ((cloud-platform-environments-pr-git-access-token))
     git_crypt_key: ((cloud-platform-environments-git-crypt.key))
-    paths:
-    - namespaces/live.cloud-platform.service.justice.gov.uk
 - name: pipeline-tools-image
   type: docker-image
   source:


### PR DESCRIPTION
Overview
---

Due to the way the cloud-platform-environments repository is setup, if you raise a PR that doesn't meet the paths glob it cannot be merged. This change removes the need for a paths globs, which means the terraform plan pipeline will run regardless of the files changed.
