### PR TITLE
Change how infrastructure reports status to GitHub

### DIFF
--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -148,15 +148,19 @@ jobs:
                       -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
-            on_failure:
-              put: pull-request
-              params:
-                path: pull-request
-                status: failure
-          - put: pull-request
-            params:
-              path: pull-request
-              status: success
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-live
+            context: plan
+      - put: pull-request
+        params:
+          path: pull-request
+          status: success
+          base_context: infrastructure-live
+          context: plan
 
   - name: terraform-apply
     serial: true
@@ -230,10 +234,10 @@ jobs:
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
 
-    on_failure:
-      put: slack-alert
-      params:
-        <<: *SLACK_NOTIFICATION_DEFAULTS
-        attachments:
-          - color: "danger"
-            <<: *SLACK_ATTACHMENTS_DEFAULTS
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -114,11 +114,6 @@ jobs:
                       -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
-            on_failure:
-              put: pull-request
-              params:
-                path: pull-request
-                status: failure
 
           - task: execute-components-plan
             image: cloud-platform-tools
@@ -148,15 +143,19 @@ jobs:
                       -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
-            on_failure:
-              put: pull-request
-              params:
-                path: pull-request
-                status: failure
-          - put: pull-request
-            params:
-              path: pull-request
-              status: success
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-manager
+            context: plan
+      - put: pull-request
+        params:
+          path: pull-request
+          status: success
+          base_context: infrastructure-manager
+          context: plan
 
   - name: terraform-apply
     serial: true
@@ -230,10 +229,10 @@ jobs:
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
 
-    on_failure:
-      put: slack-alert
-      params:
-        <<: *SLACK_NOTIFICATION_DEFAULTS
-        attachments:
-          - color: "danger"
-            <<: *SLACK_ATTACHMENTS_DEFAULTS
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
This change should report to github in two separate jobs rather than one. By changing where to failure occurs I'm hoping that in the event of one of the tasks failing, concourse will then send a failure to GitHub. The context_base and context naming is to allow both live and manager clusters to report their status individually.
