### PR TITLE
Trigger recycle node job three times per morning

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -31,13 +31,12 @@ resources:
     type: slack-notification
     source:
       url: https://hooks.slack.com/services/((slack-hook-id))
-  - name: every-day-during-workdays
+  - name: every-1h-between-midnight-3am
     type: time
     source:
-      days: [Monday, Tuesday, Wednesday, Thursday, Friday]
-      interval: 24h
-      start: 8:00 AM
-      stop: 10:00 AM
+      interval: 1h
+      start: 00:00 AM
+      stop: 03:00 AM
   - name: every-hour
     type: time
     source:
@@ -62,7 +61,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-          - get: every-day-during-workdays # For now we want to trigger during work hours only. This will eventually change when we get more confident in this tool.
+          - get: every-1h-between-midnight-3am
             trigger: true
           - get: cloud-platform-cli
       - task: recycle-oldest-node


### PR DESCRIPTION
This PR re-instates the previous recycle schedule. We changed it when the tool was re-written, but now feel like it can be trusted.