### PR TITLE
Add on_success for execute-components-plan task

### DIFF
--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -116,11 +116,6 @@ jobs:
                       -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
-            on_failure:
-              put: pull-request
-              params:
-                path: pull-request
-                status: failure
 
           - task: execute-components-plan
             image: cloud-platform-tools
@@ -149,12 +144,7 @@ jobs:
                       -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
-                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
-            on_failure:
-              put: pull-request
-              params:
-                path: pull-request
-                status: failure       
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'    
         on_failure:
           put: pull-request
           params:
@@ -162,12 +152,13 @@ jobs:
             status: failure
             base_context: infrastructure-live
             context: plan
-      - put: pull-request
-        params:
-          path: pull-request
-          status: success
-          base_context: infrastructure-live
-          context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-live
+            context: plan
 
   - name: terraform-apply
     serial: true

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -150,6 +150,11 @@ jobs:
                       -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+            on_failure:
+              put: pull-request
+              params:
+                path: pull-request
+                status: failure       
         on_failure:
           put: pull-request
           params:

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -152,12 +152,13 @@ jobs:
             status: failure
             base_context: infrastructure-manager
             context: plan
-      - put: pull-request
-        params:
-          path: pull-request
-          status: success
-          base_context: infrastructure-manager
-          context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-manager
+            context: plan
 
   - name: terraform-apply
     serial: true


### PR DESCRIPTION
execute-components-plan returns success by default. Add on_success step hook to return success.
This also fix the pipeline which is always green irrespective of failure or success