### PR TITLE
Remove ruby tests from all pipelines

### DIFF
--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -132,37 +132,7 @@ jobs:
             passed:
               - create-cluster-eks
       - in_parallel:
-          - task: run-integration-tests-rspec
-            image: tools-image
-            config:
-              platform: linux
-              params:
-                <<: *common_params
-              inputs:
-                - name: cloud-platform-infrastructure-repo
-                  path: ./
-                - name: keyval
-              run:
-                path: /bin/bash
-                args:
-                  - -c
-                  - |
-                    #  This will export cluster name info from the previous job create-cluster-run-tests
-                    export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
-
-                    echo "Setup kubeconfig for $CLUSTER_NAME"
-                    mkdir ${HOME}/.aws
-                    echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
-                    aws eks --region eu-west-2 update-kubeconfig --name $CLUSTER_NAME
-
-                    # rename-context as rspec tests expect context as "CLUSTER_NAME.cloud-platform.service.justice.gov.uk"
-                    kubectl config rename-context arn:aws:eks:eu-west-2:754256621582:cluster/$CLUSTER_NAME  $CLUSTER_NAME.cloud-platform.service.justice.gov.uk
-                    kubectl config use-context $CLUSTER_NAME.cloud-platform.service.justice.gov.uk
-
-                    echo "Run rspec integration tests for $CLUSTER_NAME"
-                    cd smoke-tests; bundle binstubs bundler --force --path /usr/local/bin; bundle binstubs rspec-core --path /usr/local/bin;
-                    rspec --tag ~live-1 --tag ~kops --tag ~concourse-test --format progress --format documentation --out ./$CLUSTER_NAME-rspec.txt
-          - task: run-integration-tests-golang
+          - task: ginkgo-tests
             image: go-integration-test-image
             config:
               platform: linux
@@ -185,8 +155,9 @@ jobs:
                     echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
                     aws eks --region eu-west-2 update-kubeconfig --name $CLUSTER_NAME
 
-                    echo "Run golang integration tests for $CLUSTER_NAME"
-                    cd ./test; ginkgo -v . -args -ginkgo.randomizeAllSpecs -ginkgo.progress -ginkgo.noisySkippings -test.v -ginkgo.slowSpecThreshold=120
+                    echo "Run go integration tests for $CLUSTER_NAME"
+                    # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
+                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
         on_failure: *slack_failure_notification
 
   - name: destroy-cluster

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -31,14 +31,7 @@ resources:
     source:
       uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
       branch: main
-  - name: rspec-integration-test-image
-    type: docker-image
-    source:
-      repository: registry.hub.docker.com/ministryofjustice/cloud-platform-smoke-tests
-      tag: "1.8"
-      username: ((ministryofjustice-dockerhub.dockerhub_username))
-      password: ((ministryofjustice-dockerhub.dockerhub_password))
-  - name: go-integration-test-image
+  - name: cloud-platform-infrastructure-image
     type: docker-image
     source:
       repository: registry.hub.docker.com/ministryofjustice/cloud-platform-infrastructure
@@ -143,29 +136,7 @@ jobs:
             trigger: false
           - get: cloud-platform-infrastructure-repo
             trigger: false
-      - in_parallel:
-          - task: run-rspec-tests
-            image: rspec-integration-test-image
-            config:
-              platform: linux
-              inputs:
-                - name: cloud-platform-infrastructure-repo
-              outputs:
-                - name: metadata
-              params:
-                <<: *AWS_CREDENTIALS
-                <<: *KUBECONFIG_PARAMS
-                KUBE_CLUSTER: live.cloud-platform.service.justice.gov.uk
-                EXECUTION_CONTEXT: integration-test-pipeline
-              run:
-                path: /bin/sh
-                dir: cloud-platform-infrastructure-repo
-                args:
-                  - -c
-                  - |
-                    aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
-                    kubectl config use-context ${KUBE_CLUSTER}
-                    cd ./smoke-tests; rspec --tag ~cluster:test-cluster-only --tag ~live-1 --tag ~kops --tag ~concourse-test
+      - do:
           - task: run-go-tests
             image: go-integration-test-image
             config:
@@ -190,7 +161,7 @@ jobs:
                     kubectl config use-context ${KUBE_CLUSTER}
 
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=3 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
 
         on_failure: *slack_failure_notification
 
@@ -206,30 +177,7 @@ jobs:
             trigger: false
           - get: cloud-platform-infrastructure-repo
             trigger: false
-      - in_parallel:
-          - task: run-rspec-tests
-            image: rspec-integration-test-image
-            config:
-              platform: linux
-              inputs:
-                - name: cloud-platform-infrastructure-repo
-              outputs:
-                - name: metadata
-              params:
-                <<: *AWS_CREDENTIALS
-                <<: *KUBECONFIG_PARAMS
-                KUBE_CLUSTER: manager.cloud-platform.service.justice.gov.uk
-                EXECUTION_CONTEXT: integration-test-pipeline
-              run:
-                path: /bin/sh
-                dir: cloud-platform-infrastructure-repo
-                args:
-                  - -c
-                  - |
-                    aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
-                    kubectl config use-context ${KUBE_CLUSTER}
-                    cd ./smoke-tests; rspec --tag ~cluster:test-cluster-only --tag ~live-1 --tag ~kops
-
+      - do:
           - task: run-go-tests
             image: go-integration-test-image
             config:
@@ -254,7 +202,7 @@ jobs:
                     kubectl config use-context ${KUBE_CLUSTER}
 
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=3 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
         on_failure: *slack_failure_notification
 
   - name: rds-manual-snapshots-checker

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -130,15 +130,13 @@ jobs:
       - in_parallel:
           - get: every-hour
             trigger: true
-          - get: rspec-integration-test-image
-            trigger: false
-          - get: go-integration-test-image
+          - get: cloud-platform-infrastructure-image
             trigger: false
           - get: cloud-platform-infrastructure-repo
             trigger: false
       - do:
           - task: run-go-tests
-            image: go-integration-test-image
+            image: cloud-platform-infrastructure-image
             config:
               platform: linux
               inputs:
@@ -171,15 +169,13 @@ jobs:
       - in_parallel:
           - get: every-6-hours
             trigger: true
-          - get: rspec-integration-test-image
-            trigger: false
-          - get: go-integration-test-image
+          - get: cloud-platform-infrastructure-image
             trigger: false
           - get: cloud-platform-infrastructure-repo
             trigger: false
       - do:
           - task: run-go-tests
-            image: go-integration-test-image
+            image: cloud-platform-infrastructure-image
             config:
               platform: linux
               inputs:


### PR DESCRIPTION
Overtime we have replaced the Rspec tests with Go. Once this PR is merged, the `smoke-tests` directory will be removed from `infrastructure`.