### PR TITLE
Remove an unused argument from create-cluster.rb execution

### DIFF
--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -13,10 +13,10 @@ resources:
       uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
       branch: main
       git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
-  - name: tools-image-eks
+  - name: cloud-platform-infrastructure-image
     type: docker-image
     source:
-      repository: ministryofjustice/cloud-platform-tools
+      repository: ministryofjustice/cloud-platform-infrastructure
       tag: "2.2.3"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
@@ -24,6 +24,8 @@ resources:
     type: slack-notification
     source:
       url: https://hooks.slack.com/services/((slack-hook-id))
+  - name: keyval
+    type: keyval
 
 resource_types:
   - name: slack-notification
@@ -33,6 +35,10 @@ resource_types:
       tag: latest
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: keyval
+    type: docker-image
+    source:
+      repository: swce/keyval-resource
 
 slack_failure_notification: &slack_failure_notification
   put: slack-alert
@@ -55,19 +61,20 @@ common_params: &common_params
 groups:
   - name: cluster-test
     jobs:
-      - build-eks-test-cluster
+      - build
+      - test
 
 jobs:
-  - name: build-eks-test-cluster
+  - name: build
     serial: true
     plan:
       - in_parallel:
           - get: cloud-platform-infrastructure-repo
             trigger: false
-          - get: tools-image-eks
+          - get: cloud-platform-infrastructure-image
             trigger: false
-      - task: build-eks-test-cluster
-        image: tools-image-eks
+      - task: build-cluster
+        image: cloud-platform-infrastructure-image
         config:
           platform: linux
           params:
@@ -75,6 +82,8 @@ jobs:
           inputs:
             - name: cloud-platform-infrastructure-repo
               path: ./
+          outputs:
+            - name: keyval
           run:
             path: /bin/sh
             args:
@@ -85,4 +94,51 @@ jobs:
                 export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
                 echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
                 ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
+
+                # keyval/keyval.properties file, will pass on the cluster name info to the next job run-integration-tests
+                echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
         on_failure: *slack_failure_notification
+      - put: keyval
+        params:
+          file: keyval/keyval.properties
+
+  - name: test
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-infrastructure-repo
+            trigger: false
+          - get: cloud-platform-infrastructure-image
+            trigger: false
+          - get: keyval
+            trigger: true
+            passed:
+              - build
+      - do:
+          - task: run-ginkgo-tests
+            image: cloud-platform-infrastructure-image
+            config:
+              platform: linux
+              params:
+                <<: *common_params
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+                  path: ./
+                - name: keyval
+              run:
+                path: /bin/sh
+                args:
+                  - -c
+                  - |
+                    #  This will export cluster name info from the previous job create-cluster-run-tests
+                    export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
+
+                    echo "Setup kubeconfig for $CLUSTER_NAME"
+                    mkdir ${HOME}/.aws
+                    echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                    aws eks --region eu-west-2 update-kubeconfig --name $CLUSTER_NAME
+
+                    echo "Run go integration tests for $CLUSTER_NAME"
+                    # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
+                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --fail-on-pending --race --trace
+            on_failure: *slack_failure_notification

--- a/pipelines/manager/main/build-test-cluster.yaml
+++ b/pipelines/manager/main/build-test-cluster.yaml
@@ -92,8 +92,8 @@ jobs:
                 mkdir ${HOME}/.aws
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # Cheating create-cluster.rb script, it forces you to have profiles :-(
                 export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
-                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
-                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
+                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900"
+                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900
 
                 # keyval/keyval.properties file, will pass on the cluster name info to the next job run-integration-tests
                 echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties

--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -103,8 +103,8 @@ jobs:
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
 
                 export CLUSTER_NAME=yy-$(date +%d%m-%H%M)
-                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test"
-                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900 --no-integration-test
+                echo "Executing: ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900"
+                ./create-cluster.rb --no-gitcrypt -n $CLUSTER_NAME -v $CLUSTER_NAME -t 900
 
                 # keyval/keyval.properties file, will pass on the cluster name info to the next job run-integration-tests
                 echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
@@ -157,7 +157,7 @@ jobs:
 
                     echo "Run go integration tests for $CLUSTER_NAME"
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --fail-on-pending --race --trace
         on_failure: *slack_failure_notification
 
   - name: destroy-cluster


### PR DESCRIPTION
- feat(build-test-cluster): add additional plan to test new cluster
- refactor(cluster): remove the `--no-integrationtest` argument
