### PR TITLE
Fix test timeout and yaml anchor errors

### DIFF
--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -157,7 +157,7 @@ jobs:
 
                     echo "Run go integration tests for $CLUSTER_NAME"
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=2 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
         on_failure: *slack_failure_notification
 
   - name: destroy-cluster

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -1,77 +1,94 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+  KUBECONFIG_S3_KEY: kubeconfig
+  KUBECONFIG: /tmp/kubeconfig
+  KUBE_CONFIG_PATH: /tmp/kubeconfig
+
+pingdom: &PINGDOM_PARAMS
+  PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+
 slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
-  channel: '#lower-priority-alarms'
+  channel: "#lower-priority-alarms"
   silent: true
+
 slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
-  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
-  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
-  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
   footer: concourse.cloud-platform.service.justice.gov.uk
 
 resources:
-- name: cloud-platform-environments-repo
-  type: git
-  source:
-    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
-    branch: main
-    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
-- name: cloud-platform-environments-live-pull-requests
-  type: pull-request
-  check_every: 1m
-  source:
-    repository: ministryofjustice/cloud-platform-environments
-    access_token: ((cloud-platform-environments-pr-git-access-token))
-    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
-- name: pipeline-tools-image
-  type: docker-image
-  source:
-    repository: ministryofjustice/cloud-platform-pipeline-tools
-    tag: "2.1"
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: slack-alert
-  type: slack-notification
-  source:
-    url: https://hooks.slack.com/services/((slack-hook-id))
-- name: every-120m
-  type: time
-  source:
-    interval: 120m
+  - name: cloud-platform-environments-repo
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+      branch: main
+      git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+  - name: cloud-platform-environments-live-pull-requests
+    type: pull-request
+    check_every: 1m
+    source:
+      repository: ministryofjustice/cloud-platform-environments
+      access_token: ((cloud-platform-environments-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+  - name: pipeline-tools-image
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-pipeline-tools
+      tag: "2.1"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-hook-id))
+  - name: every-120m
+    type: time
+    source:
+      interval: 120m
 
 resource_types:
-- name: slack-notification
-  type: docker-image
-  source:
-    repository: cfcommunity/slack-notification-resource
-    tag: latest
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
-- name: pull-request
-  type: docker-image
-  source:
-    repository: teliaoss/github-pr-resource
-    username: ((ministryofjustice-dockerhub.dockerhub_username))
-    password: ((ministryofjustice-dockerhub.dockerhub_password))
-
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
 
 groups:
-- name: environments-terraform
-  jobs:
-    - apply-live
-    - apply-namespace-changes-live
-    - plan-live
-    - detect-deleted-namespaces
-    - destroy-deleted-namespaces
+  - name: environments-terraform
+    jobs:
+      - apply-live
+      - apply-namespace-changes-live
+      - plan-live
+      - apply-dev-alpha
+      - apply-namespace-changes-dev-alpha
+      - plan-dev-alpha
+      - detect-deleted-namespaces
+      - destroy-deleted-namespaces
 
 jobs:
   - name: apply-live
     serial: true
     plan:
       - in_parallel:
-        - get: every-120m
-          trigger: true
-        - get: cloud-platform-environments-repo
-          trigger: false
-        - get: pipeline-tools-image
+          - get: every-120m
+            trigger: true
+          - get: cloud-platform-environments-repo
+            trigger: false
+          - get: pipeline-tools-image
       - task: apply-environments
         timeout: 4h
         image: pipeline-tools-image
@@ -80,12 +97,10 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG: /tmp/kubeconfig
-            KUBE_CONFIG_PATH: /tmp/kubeconfig
-            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
-            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            <<: *PINGDOM_PARAMS
+
             # the variables prefixed with PIPELINE_ are used by the apply script
             PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
@@ -93,9 +108,8 @@ jobs:
             PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
-            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
-            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
-            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
+
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
@@ -126,9 +140,9 @@ jobs:
     serial: false
     plan:
       - in_parallel:
-        - get: cloud-platform-environments-repo
-          trigger: true
-        - get: pipeline-tools-image
+          - get: cloud-platform-environments-repo
+            trigger: true
+          - get: pipeline-tools-image
       - task: apply-namespace-changes
         timeout: 1h
         image: pipeline-tools-image
@@ -137,12 +151,11 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG: /tmp/kubeconfig
-            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            <<: *PINGDOM_PARAMS
+
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
-            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the apply script
             PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
@@ -150,9 +163,6 @@ jobs:
             PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
-            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
-            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
-            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
@@ -198,12 +208,11 @@ jobs:
           inputs:
             - name: cloud-platform-environments-live-pull-requests
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG: /tmp/kubeconfig
-            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            <<: *PINGDOM_PARAMS
+
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
-            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the plan script
             PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
@@ -214,9 +223,6 @@ jobs:
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
-            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
-            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
-            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
             TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
@@ -235,23 +241,23 @@ jobs:
                 bundle install --without development test
                 ./bin/plan
         on_failure:
-            put: cloud-platform-environments-live-pull-requests
-            params:
-              path: cloud-platform-environments-live-pull-requests
-              status: failure
+          put: cloud-platform-environments-live-pull-requests
+          params:
+            path: cloud-platform-environments-live-pull-requests
+            status: failure
         on_success:
-            put: cloud-platform-environments-live-pull-requests
-            params:
-              path: cloud-platform-environments-live-pull-requests
-              status: success
+          put: cloud-platform-environments-live-pull-requests
+          params:
+            path: cloud-platform-environments-live-pull-requests
+            status: success
 
   - name: detect-deleted-namespaces
     serial: true
     plan:
       - in_parallel:
-        - get: cloud-platform-environments-repo
-          trigger: true
-        - get: pipeline-tools-image
+          - get: cloud-platform-environments-repo
+            trigger: true
+          - get: pipeline-tools-image
       - task: detect-deleted-namespaces
         image: pipeline-tools-image
         config:
@@ -259,12 +265,10 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBE_CONFIG: /tmp/kubeconfig
-            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            <<: *PINGDOM_PARAMS
+
             KUBE_CTX: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
@@ -297,9 +301,9 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: cloud-platform-environments-repo
-          trigger: true
-        - get: pipeline-tools-image
+          - get: cloud-platform-environments-repo
+            trigger: true
+          - get: pipeline-tools-image
       - task: destroy-deleted-namespaces
         image: pipeline-tools-image
         config:
@@ -307,12 +311,10 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBE_CONFIG: /tmp/kubeconfig
-            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            <<: *AWS_CREDENTIALS
+            <<: *KUBECONFIG_PARAMS
+            <<: *PINGDOM_PARAMS
+
             KUBE_CTX: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -1,94 +1,77 @@
-aws-credentials: &AWS_CREDENTIALS
-  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-  AWS_REGION: eu-west-2
-
-kube-config: &KUBECONFIG_PARAMS
-  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-  KUBECONFIG_S3_KEY: kubeconfig
-  KUBECONFIG: /tmp/kubeconfig
-  KUBE_CONFIG_PATH: /tmp/kubeconfig
-
-pingdom: &PINGDOM_PARAMS
-  PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
-
 slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
-  channel: "#lower-priority-alarms"
+  channel: '#lower-priority-alarms'
   silent: true
-
 slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
-  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
-  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
-  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+  title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
   footer: concourse.cloud-platform.service.justice.gov.uk
 
 resources:
-  - name: cloud-platform-environments-repo
-    type: git
-    source:
-      uri: https://github.com/ministryofjustice/cloud-platform-environments.git
-      branch: main
-      git_crypt_key: ((cloud-platform-environments-git-crypt.key))
-  - name: cloud-platform-environments-live-pull-requests
-    type: pull-request
-    check_every: 1m
-    source:
-      repository: ministryofjustice/cloud-platform-environments
-      access_token: ((cloud-platform-environments-pr-git-access-token))
-      git_crypt_key: ((cloud-platform-environments-git-crypt.key))
-  - name: pipeline-tools-image
-    type: docker-image
-    source:
-      repository: ministryofjustice/cloud-platform-pipeline-tools
-      tag: "2.1"
-      username: ((ministryofjustice-dockerhub.dockerhub_username))
-      password: ((ministryofjustice-dockerhub.dockerhub_password))
-  - name: slack-alert
-    type: slack-notification
-    source:
-      url: https://hooks.slack.com/services/((slack-hook-id))
-  - name: every-120m
-    type: time
-    source:
-      interval: 120m
+- name: cloud-platform-environments-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
+    branch: main
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: cloud-platform-environments-live-pull-requests
+  type: pull-request
+  check_every: 1m
+  source:
+    repository: ministryofjustice/cloud-platform-environments
+    access_token: ((cloud-platform-environments-pr-git-access-token))
+    git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: pipeline-tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-pipeline-tools
+    tag: "2.1"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-120m
+  type: time
+  source:
+    interval: 120m
 
 resource_types:
-  - name: slack-notification
-    type: docker-image
-    source:
-      repository: cfcommunity/slack-notification-resource
-      tag: latest
-      username: ((ministryofjustice-dockerhub.dockerhub_username))
-      password: ((ministryofjustice-dockerhub.dockerhub_password))
-  - name: pull-request
-    type: docker-image
-    source:
-      repository: teliaoss/github-pr-resource
-      username: ((ministryofjustice-dockerhub.dockerhub_username))
-      password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
 
 groups:
-  - name: environments-terraform
-    jobs:
-      - apply-live
-      - apply-namespace-changes-live
-      - plan-live
-      - apply-dev-alpha
-      - apply-namespace-changes-dev-alpha
-      - plan-dev-alpha
-      - detect-deleted-namespaces
-      - destroy-deleted-namespaces
+- name: environments-terraform
+  jobs:
+    - apply-live
+    - apply-namespace-changes-live
+    - plan-live
+    - detect-deleted-namespaces
+    - destroy-deleted-namespaces
 
 jobs:
   - name: apply-live
     serial: true
     plan:
       - in_parallel:
-          - get: every-120m
-            trigger: true
-          - get: cloud-platform-environments-repo
-            trigger: false
-          - get: pipeline-tools-image
+        - get: every-120m
+          trigger: true
+        - get: cloud-platform-environments-repo
+          trigger: false
+        - get: pipeline-tools-image
       - task: apply-environments
         timeout: 4h
         image: pipeline-tools-image
@@ -97,10 +80,12 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            <<: *AWS_CREDENTIALS
-            <<: *KUBECONFIG_PARAMS
-            <<: *PINGDOM_PARAMS
-
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the apply script
             PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
@@ -108,8 +93,9 @@ jobs:
             PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
-
-            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
@@ -140,9 +126,9 @@ jobs:
     serial: false
     plan:
       - in_parallel:
-          - get: cloud-platform-environments-repo
-            trigger: true
-          - get: pipeline-tools-image
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: pipeline-tools-image
       - task: apply-namespace-changes
         timeout: 1h
         image: pipeline-tools-image
@@ -151,11 +137,12 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            <<: *AWS_CREDENTIALS
-            <<: *KUBECONFIG_PARAMS
-            <<: *PINGDOM_PARAMS
-
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the apply script
             PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
@@ -163,6 +150,9 @@ jobs:
             PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_REGION: "eu-west-1"
             PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
@@ -208,11 +198,12 @@ jobs:
           inputs:
             - name: cloud-platform-environments-live-pull-requests
           params:
-            <<: *AWS_CREDENTIALS
-            <<: *KUBECONFIG_PARAMS
-            <<: *PINGDOM_PARAMS
-
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
             TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PINGDOM_API_TOKEN: ((cloud-platform-environments-pingdom.pingdom_api_token))
             # the variables prefixed with PIPELINE_ are used by the plan script
             PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
@@ -223,6 +214,9 @@ jobs:
             # the variable cluster_name here is used to get VPC info
             TF_VAR_cluster_name: "live-1"
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
+            TF_VAR_concourse_url: "https://concourse.cloud-platform.service.justice.gov.uk"
+            TF_VAR_concourse_basic_auth_username: ((concourse-basic-auth.username))
+            TF_VAR_concourse_basic_auth_password: ((concourse-basic-auth.password))
             TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
@@ -241,23 +235,23 @@ jobs:
                 bundle install --without development test
                 ./bin/plan
         on_failure:
-          put: cloud-platform-environments-live-pull-requests
-          params:
-            path: cloud-platform-environments-live-pull-requests
-            status: failure
+            put: cloud-platform-environments-live-pull-requests
+            params:
+              path: cloud-platform-environments-live-pull-requests
+              status: failure
         on_success:
-          put: cloud-platform-environments-live-pull-requests
-          params:
-            path: cloud-platform-environments-live-pull-requests
-            status: success
+            put: cloud-platform-environments-live-pull-requests
+            params:
+              path: cloud-platform-environments-live-pull-requests
+              status: success
 
   - name: detect-deleted-namespaces
     serial: true
     plan:
       - in_parallel:
-          - get: cloud-platform-environments-repo
-            trigger: true
-          - get: pipeline-tools-image
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: pipeline-tools-image
       - task: detect-deleted-namespaces
         image: pipeline-tools-image
         config:
@@ -265,10 +259,12 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            <<: *AWS_CREDENTIALS
-            <<: *KUBECONFIG_PARAMS
-            <<: *PINGDOM_PARAMS
-
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBE_CONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
             KUBE_CTX: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
@@ -301,9 +297,9 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-          - get: cloud-platform-environments-repo
-            trigger: true
-          - get: pipeline-tools-image
+        - get: cloud-platform-environments-repo
+          trigger: true
+        - get: pipeline-tools-image
       - task: destroy-deleted-namespaces
         image: pipeline-tools-image
         config:
@@ -311,10 +307,12 @@ jobs:
           inputs:
             - name: cloud-platform-environments-repo
           params:
-            <<: *AWS_CREDENTIALS
-            <<: *KUBECONFIG_PARAMS
-            <<: *PINGDOM_PARAMS
-
+            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+            KUBECONFIG_S3_KEY: kubeconfig
+            KUBE_CONFIG: /tmp/kubeconfig
+            KUBE_CONFIG_PATH: /tmp/kubeconfig
             KUBE_CTX: live.cloud-platform.service.justice.gov.uk
             PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
             PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -144,8 +144,7 @@ jobs:
               outputs:
                 - name: metadata
               params:
-                <<: *AWS_CREDENTIALS
-                <<: *KUBECONFIG_PARAMS
+                <<: [*AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
                 KUBE_CLUSTER: live.cloud-platform.service.justice.gov.uk
                 EXECUTION_CONTEXT: integration-test-pipeline
                 KUBECONFIG: /root/.kube/config
@@ -159,7 +158,7 @@ jobs:
                     kubectl config use-context ${KUBE_CLUSTER}
 
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=2 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
 
         on_failure: *slack_failure_notification
 
@@ -183,11 +182,9 @@ jobs:
               outputs:
                 - name: metadata
               params:
-                <<: *AWS_CREDENTIALS
-                <<: *KUBECONFIG_PARAMS
+                <<: [*AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
                 KUBE_CLUSTER: manager.cloud-platform.service.justice.gov.uk
                 EXECUTION_CONTEXT: integration-test-pipeline
-                KUBECONFIG: /root/.kube/config
               run:
                 path: /bin/sh
                 dir: cloud-platform-infrastructure-repo
@@ -198,7 +195,7 @@ jobs:
                     kubectl config use-context ${KUBE_CLUSTER}
 
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r --timeout=2400s --progress --succinct --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
         on_failure: *slack_failure_notification
 
   - name: rds-manual-snapshots-checker


### PR DESCRIPTION
This PR changes the flaky test retry from 3 to 2 so we get a succinct failure, rather than the panic displayed here: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/reporting/jobs/live-integration-tests/builds/5290.

It also fixes an anchoring error a yaml linter complains about.

