### PR TITLE
Change flaky tests from 3 to 2

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -195,7 +195,7 @@ jobs:
                     kubectl config use-context ${KUBE_CLUSTER}
 
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
-                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
+                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=2 --slow-spec-threshold=120s --procs=6 --compilers=3 --fail-on-pending --race --trace
         on_failure: *slack_failure_notification
 
   - name: rds-manual-snapshots-checker


### PR DESCRIPTION
This was missed in a previous PR and will fix the error outlined here:
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/reporting/jobs/manager-integration-tests/builds/159
