### PR TITLE
Add pipeline to do plan/apply account level, global-resources terraform changes

### DIFF
--- a/pipelines/manager/main/infrastructure-account.yaml
+++ b/pipelines/manager/main/infrastructure-account.yaml
@@ -1,0 +1,161 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+auth0: &AUTH0_CONF
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: "#lower-priority-alarms"
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  footer: concourse.cloud-platform.service.justice.gov.uk/
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: "0.23.0"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+resources:
+  - name: cloud-platform-tools
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-tools
+      tag: "2.2.5"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      disable_forks: true
+      ignore_drafts: false
+      base_branch: main
+      repository: ministryofjustice/cloud-platform-infrastructure
+      access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+  - name: merged-pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      disable_forks: true
+      repository: ministryofjustice/cloud-platform-infrastructure
+      access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      states: ["MERGED"]
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-hook-id))
+
+groups:
+  - name: infrastructure-cloud-platform-aws-vpc
+    jobs:
+      - terraform-plan
+      - terraform-apply
+
+jobs:
+  - name: terraform-plan
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: pull-request
+            trigger: true
+            version: every
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+          base_context: infrastructure-cloud-platform-aws-vpc
+          context: plan
+      - in_parallel:
+          - task: execute-cloud-platform-aws-vpc
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/account
+                args:
+                  - -c
+                  - |
+                    terraform init
+                    terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-cloud-platform-aws-account
+            context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-cloud-platform-aws-vpc
+            context: plan
+
+  - name: terraform-apply
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: merged-pull-request
+            trigger: true
+            version: every
+      - put: merged-pull-request
+        params:
+          path: merged-pull-request
+      - in_parallel:
+          - task: execute-cloud-platform-aws-vpc
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS]
+              inputs:
+                - name: merged-pull-request
+              run:
+                path: /bin/bash
+                dir: merged-pull-request/terraform/aws-accounts/cloud-platform-aws/account
+                args:
+                  - -c
+                  - |
+                    terraform init
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/infrastructure-global-resources.yaml
+++ b/pipelines/manager/main/infrastructure-global-resources.yaml
@@ -62,7 +62,7 @@ resources:
       url: https://hooks.slack.com/services/((slack-hook-id))
 
 groups:
-  - name: infrastructure-cloud-platform-aws-account
+  - name: infrastructure-global-resources
     jobs:
       - terraform-plan
       - terraform-apply
@@ -80,10 +80,10 @@ jobs:
         params:
           path: pull-request
           status: pending
-          base_context: infrastructure-cloud-platform-aws-account 
+          base_context: infrastructure-global-resources
           context: plan
       - in_parallel:
-          - task: execute-cloud-platform-aws-account
+          - task: execute-infrastructure-global-resources
             image: cloud-platform-tools
             config:
               platform: linux
@@ -93,7 +93,7 @@ jobs:
                 - name: pull-request
               run:
                 path: /bin/bash
-                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/account
+                dir: pull-request/terraform/global-resources
                 args:
                   - -c
                   - |
@@ -109,14 +109,14 @@ jobs:
           params:
             path: pull-request
             status: failure
-            base_context: infrastructure-cloud-platform-aws-account
+            base_context: infrastructure-global-resources
             context: plan
         on_success:
           put: pull-request
           params:
             path: pull-request
             status: success
-            base_context: infrastructure-cloud-platform-aws-account
+            base_context: infrastructure-global-resources
             context: plan
 
   - name: terraform-apply
@@ -131,7 +131,7 @@ jobs:
         params:
           path: merged-pull-request
       - in_parallel:
-          - task: execute-cloud-platform-aws-account
+          - task: execute-infrastructure-global-resources
             image: cloud-platform-tools
             config:
               platform: linux
@@ -141,7 +141,7 @@ jobs:
                 - name: merged-pull-request
               run:
                 path: /bin/bash
-                dir: merged-pull-request/terraform/aws-accounts/cloud-platform-aws/account
+                dir: merged-pull-request/terraform/global-resources
                 args:
                   - -c
                   - |


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/4008

This pipeline triggers on PR to account/ folder changes comparing terraform state with the `cloud-platform-aws` account and apply the terraform changes.

To run this pipeline manually, you will need aws credentials for `cloud-platform-aws` and `auth0` credentials for the Auth0 account which defaults to  `justice-cloud-platform.eu.auth0.com`