### PR TITLE
Add permissions to run account/global, add moj-cp profile to pipelines

### DIFF
--- a/pipelines/manager/main/infrastructure-account.yaml
+++ b/pipelines/manager/main/infrastructure-account.yaml
@@ -2,6 +2,7 @@ aws-credentials: &AWS_CREDENTIALS
   AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
   AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
   AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
 
 auth0: &AUTH0_CONF
   AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
@@ -97,6 +98,8 @@ jobs:
                 args:
                   - -c
                   - |
+                    mkdir ${HOME}/.aws
+                    echo -e "[moj-cp]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> ${HOME}/.aws/credentials # This forces you to have profiles
                     terraform init
                     terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
                       sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
@@ -146,6 +149,8 @@ jobs:
                 args:
                   - -c
                   - |
+                    mkdir ${HOME}/.aws
+                    echo -e "[moj-cp]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> ${HOME}/.aws/credentials # This forces you to have profiles
                     terraform init
                     terraform apply -input=false -lock-timeout=3m -auto-approve | \
                       sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \

--- a/pipelines/manager/main/infrastructure-global-resources.yaml
+++ b/pipelines/manager/main/infrastructure-global-resources.yaml
@@ -2,6 +2,7 @@ aws-credentials: &AWS_CREDENTIALS
   AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
   AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
   AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
 
 auth0: &AUTH0_CONF
   AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
@@ -97,6 +98,8 @@ jobs:
                 args:
                   - -c
                   - |
+                    mkdir ${HOME}/.aws
+                    echo -e "[moj-cp]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> ${HOME}/.aws/credentials # This forces you to have profiles
                     terraform init
                     terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
                       sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
@@ -146,6 +149,8 @@ jobs:
                 args:
                   - -c
                   - |
+                    mkdir ${HOME}/.aws
+                    echo -e "[moj-cp]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY" >> ${HOME}/.aws/credentials # This forces you to have profiles
                     terraform init
                     terraform apply -input=false -lock-timeout=3m -auto-approve | \
                       sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \

--- a/policy.tf
+++ b/policy.tf
@@ -516,6 +516,8 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
 
+    /* End of permissions for concourse pipeline cost reporter */
+
  /*
 
     The permissions below enable the concourse pipeline to run the 
@@ -533,8 +535,80 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
  
+   /* End of permissions for concourse pipeline global-resources */
+ 
+ /*
+    The permissions below enable the concourse pipeline to run the 
+    cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/account to 
+    invoke lambda functions, system manager, 
 
-  /* End of permissions for concourse pipeline cost reporter */
+
+   */
+  statement {
+    actions = [
+      "ssm:GetDocument",
+      "ssm:DescribeAssociation",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+  statement {
+    actions = [
+      "lambda:ListLayerVersions",
+      "lambda:ListEventSourceMappings",
+      "lambda:ListFunctions",
+      "lambda:ListCodeSigningConfigs",
+      "lambda:ListLayers",
+      "lambda:GetAccountSettings",
+      "lambda:CreateEventSourceMapping",
+      "lambda:CreateCodeSigningConfig",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "events:ListTargetsByRule",
+      "events:DescribeRule",
+      "events:ListTagsForResource",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+
+  statement {
+    actions = [
+      "cloudtrail:ListTags",
+      "cloudtrail:GetEventSelectors",
+      "cloudtrail:GetTrailStatus",
+      "cloudtrail:DescribeTrails",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+
+  statement {
+    actions = [
+      "iam:GetPolicyVersion",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  /* End of permissions for concourse pipeline cloud-platform-aws account */
 }
 
 resource "aws_iam_policy" "policy" {


### PR DESCRIPTION
This PR:
- Add moj-cp profile with credentials to the ~/.aws/credentials which are needed to run terraform/cloud-platform-aws/account and terraform/global-resources
- Add permissions to run terraform/cloud-platform-aws/account and terraform/global-resources