### PR TITLE
Split policy as there are chars restrictions of 6144

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -619,9 +619,9 @@ resource "aws_iam_policy" "policy" {
 }
 
 resource "aws_iam_policy" "global_account_policy" {
-  name        = "${terraform.workspace}-concourse-global_account-policy"
+  name        = "${terraform.workspace}-concourse-global-account-policy"
   path        = "/cloud-platform/"
-  policy      = data.aws_iam_policy_document.global_policy.json
+  policy      = data.aws_iam_policy_document.global_account_policy.json
   description = "Policy for ${terraform.workspace}-concourse to apply infrastructure - global-resources and account pipelines"
 }
 

--- a/policy.tf
+++ b/policy.tf
@@ -516,10 +516,12 @@ data "aws_iam_policy_document" "policy" {
     ]
   }
 
-    /* End of permissions for concourse pipeline cost reporter */
+  /* End of permissions for concourse pipeline cost reporter */
 
- /*
+}
 
+data "aws_iam_policy_document" "global_account_policy" {
+  /*
     The permissions below enable the concourse pipeline to run the 
     cloud-platform-infrastructure/terraform/gloal-resources to monitoring Elasticsearch cloudwatch alarms 
 
@@ -534,15 +536,13 @@ data "aws_iam_policy_document" "policy" {
       "arn:aws:cloudwatch:*:*:alarm:*",
     ]
   }
- 
-   /* End of permissions for concourse pipeline global-resources */
- 
- /*
+
+  /* End of permissions for concourse pipeline global-resources */
+
+  /*
     The permissions below enable the concourse pipeline to run the 
     cloud-platform-infrastructure/terraform/aws-accounts/cloud-platform-aws/account to 
-    invoke lambda functions, system manager, 
-
-
+    invoke lambda functions, system manager, cloudwatch events for elasticsearch and cloudtrail
    */
   statement {
     actions = [
@@ -618,10 +618,24 @@ resource "aws_iam_policy" "policy" {
   description = "Policy for ${terraform.workspace}-concourse"
 }
 
+resource "aws_iam_policy" "global_account_policy" {
+  name        = "${terraform.workspace}-concourse-global_account-policy"
+  path        = "/cloud-platform/"
+  policy      = data.aws_iam_policy_document.global_policy.json
+  description = "Policy for ${terraform.workspace}-concourse to apply infrastructure - global-resources and account pipelines"
+}
+
 resource "aws_iam_policy_attachment" "attach_policy" {
   name       = "attached-policy"
   users      = [aws_iam_user.concourse_user.name]
   policy_arn = aws_iam_policy.policy.arn
+}
+
+
+resource "aws_iam_policy_attachment" "attach_global_account_policy" {
+  name       = "attached-global-account-policy"
+  users      = [aws_iam_user.concourse_user.name]
+  policy_arn = aws_iam_policy.global_account_policy.arn
 }
 
 # aws-admin-concourse


### PR DESCRIPTION
The policy didnot get updated because of the policy character restrictions. 
```
Error: error updating IAM policy arn:aws:iam::754256621582:policy/cloud-platform/manager-concourse-user-policy: LimitExceeded: Cannot exceed quota for PolicySize: 6144
	status code: 409, request id: ddc5f7ba-4039-4a76-ac8f-37b9e5fa6b38

  on .terraform/modules/concourse/policy.tf line 614, in resource "aws_iam_policy" "policy":
 614: resource "aws_iam_policy" "policy" {```

This PR fixes the error by spliting the policy into 2 and attaching both to the iam user.