### PR TITLE
Update env var related to vpc_name

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -102,6 +102,8 @@ jobs:
             TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
+            TF_VAR_vpc_name: "live-1"
+            TF_VAR_eks_cluster_name: "live"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo
@@ -159,6 +161,8 @@ jobs:
             TF_VAR_cluster_state_key: "cloud-platform/live/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
+            TF_VAR_vpc_name: "live-1"
+            TF_VAR_eks_cluster_name: "live"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo
@@ -220,6 +224,8 @@ jobs:
             TF_VAR_cluster_state_key: "cloud-platform/live-1/terraform.tfstate"
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
+            TF_VAR_vpc_name: "live-1"
+            TF_VAR_eks_cluster_name: "live"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-live-pull-requests
@@ -277,6 +283,8 @@ jobs:
             TF_VAR_cluster_state_bucket: cloud-platform-terraform-state
             TF_VAR_github_owner: "ministryofjustice"
             TF_VAR_github_token: ((github-actions-secrets-token.token))
+            TF_VAR_vpc_name: "live-1"
+            TF_VAR_eks_cluster_name: "live"
           run:
             path: /bin/sh
             dir: cloud-platform-environments-repo


### PR DESCRIPTION
This is to clear confusion vpc_name vs cluster_name

Once all modules using cluster_name are updated, this can be removed "TF_VAR_cluster_name"