### PR TITLE
Add new create-cluster pipeline

### DIFF
--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -1,0 +1,106 @@
+resources:
+  - name: cloud-platform-infrastructure-repository
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+      branch: main
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+
+  - name: cloud-platform-infrastructure-image
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-infrastructure
+      tag: "2.2.7"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+  - name: keyval
+    type: keyval
+
+common_params: &common_params
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+
+groups:
+  - name: create-test-cluster
+    jobs:
+      - create
+      - test
+
+jobs:
+  - name: create
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-infrastructure-repository
+          - get: cloud-platform-infrastructure-image
+
+      - task: create-test-cluster
+        image: cloud-platform-infrastructure-image
+        config:
+          platform: linux
+          params:
+            <<: *common_params
+          inputs:
+            - name: cloud-platform-infrastructure-repository
+          run:
+            path: /bin/bash
+            dir: cloud-platform-infrastructure-repository
+            args:
+              - -c
+              - |
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+
+                export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
+                cloud-platform cluster create --name $CLUSTER_NAME
+
+                # keyval/keyval.properties file, will pass on the cluster name info to the next job run-integration-tests
+                echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
+      - put: keyval
+        params:
+          file: keyval/keyval.properties
+
+  - name: test
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-infrastructure-repository
+          - get: cloud-platform-infrastructure-image
+
+          - get: keyval
+            trigger: true
+            passed:
+              - create
+      - do:
+          - task: run-ginkgo-tests
+            image: cloud-platform-infrastructure-image
+            config:
+              platform: linux
+              params:
+                <<: *common_params
+              inputs:
+                - name: cloud-platform-infrastructure-repository
+                  path: ./
+                - name: keyval
+              run:
+                path: /bin/bash
+                args:
+                  - -c
+                  - |
+                    #  This will export cluster name info from the previous job create-cluster-run-tests
+                    export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
+
+                    echo "Setup kubeconfig for $CLUSTER_NAME"
+                    mkdir ${HOME}/.aws
+                    echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                    aws eks --region eu-west-2 update-kubeconfig --name $CLUSTER_NAME
+
+                    echo "Run go integration tests for $CLUSTER_NAME"
+                    # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
+                    cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --fail-on-pending --race --trace

--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -1,3 +1,9 @@
+resource_types:
+  - name: keyval
+    type: docker-image
+    source:
+      repository: swce/keyval-resource
+
 resources:
   - name: cloud-platform-infrastructure-repository
     type: git
@@ -5,6 +11,14 @@ resources:
       uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
       branch: main
       git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+
+  - name: cloud-platform-cli-image
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-cli
+      tag: "1.22.0"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
 
   - name: cloud-platform-infrastructure-image
     type: docker-image
@@ -17,51 +31,82 @@ resources:
   - name: keyval
     type: keyval
 
-common_params: &common_params
+aws_params: &aws_params
   AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
   AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
   AWS_REGION: eu-west-2
   AWS_PROFILE: moj-cp
+
+auth0_params: &auth0_params
   AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
   AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
   AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
 
 groups:
-  - name: create-test-cluster
+  - name: create-and-test-cluster
     jobs:
+      - name
       - create
       - test
+      - destroy
 
 jobs:
+  - name: trigger
+    serial: true
+    plan:
+      - get: cloud-platform-cli-image
+
+      - task: name-the-cluster
+        image: cloud-platform-cli-image
+        config:
+          platform: linux
+          outputs:
+            - name: keyval
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
+                echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
+      - put: keyval
+        params:
+          file: keyval/keyval.properties
+
   - name: create
     serial: true
     plan:
       - in_parallel:
           - get: cloud-platform-infrastructure-repository
-          - get: cloud-platform-infrastructure-image
+          - get: cloud-platform-cli-image
+          - get: keyval
+            trigger: true
+            passed:
+              - trigger
 
-      - task: create-test-cluster
-        image: cloud-platform-infrastructure-image
+      - task: cloud-platform-cluster
+        image: cloud-platform-cli-image
         config:
           platform: linux
           params:
-            <<: *common_params
+            <<: [*aws_params, *auth0_params]
           inputs:
             - name: cloud-platform-infrastructure-repository
+            - name: keyval
+          outputs:
+            - name: keyval
           run:
             path: /bin/bash
             dir: cloud-platform-infrastructure-repository
             args:
               - -c
               - |
+                #  This will export cluster name info from the previous job "name"
+                export $(cat ../keyval/keyval.properties | grep CLUSTER_NAME )
                 mkdir ${HOME}/.aws
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
 
-                export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
-                cloud-platform cluster create --name $CLUSTER_NAME
-
-                # keyval/keyval.properties file, will pass on the cluster name info to the next job run-integration-tests
-                echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
+                cloud-platform cluster create --name $CLUSTER_NAME --skip-version-check --fast
       - put: keyval
         params:
           file: keyval/keyval.properties
@@ -83,7 +128,7 @@ jobs:
             config:
               platform: linux
               params:
-                <<: *common_params
+                <<: *aws_params
               inputs:
                 - name: cloud-platform-infrastructure-repository
                   path: ./
@@ -104,3 +149,35 @@ jobs:
                     echo "Run go integration tests for $CLUSTER_NAME"
                     # https://onsi.github.io/ginkgo/#recommended-continuous-integration-configuration
                     cd ./test;  ginkgo -r -v --timeout=2400s --progress --randomize-suites --randomize-all --keep-going --flake-attempts=3 --slow-spec-threshold=120s --fail-on-pending --race --trace
+
+  - name: destroy
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-infrastructure-repository
+          - get: cloud-platform-infrastructure-image
+          - get: keyval
+            passed:
+              - name
+      - task: destroy-test-cluster
+        image: cloud-platform-infrastructure-image
+        config:
+          platform: linux
+          params:
+            <<: [*aws_params, *auth0_params]
+          inputs:
+            - name: cloud-platform-infrastructure-repository
+              path: ./
+            - name: keyval
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                #  This will export cluster name info from the previous job create-cluster-run-tests
+                export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
+
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                echo "Executing: ./destroy-cluster.rb -n $CLUSTER_NAME"
+                ./destroy-cluster.rb --name cp-1110-1305 --yes

--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -45,7 +45,7 @@ auth0_params: &auth0_params
 groups:
   - name: create-and-test-cluster
     jobs:
-      - name
+      - trigger
       - create
       - test
       - destroy
@@ -67,6 +67,7 @@ jobs:
             args:
               - -c
               - |
+                # Create the name variable to pass to create and delete jobs
                 export CLUSTER_NAME=cp-$(date +%d%m-%H%M)
                 echo CLUSTER_NAME=$CLUSTER_NAME > keyval/keyval.properties
       - put: keyval
@@ -101,7 +102,7 @@ jobs:
             args:
               - -c
               - |
-                #  This will export cluster name info from the previous job "name"
+                #  This will export cluster name info from the "trigger" job
                 export $(cat ../keyval/keyval.properties | grep CLUSTER_NAME )
                 mkdir ${HOME}/.aws
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
@@ -138,7 +139,7 @@ jobs:
                 args:
                   - -c
                   - |
-                    #  This will export cluster name info from the previous job create-cluster-run-tests
+                    #  This will export cluster name info from the previous job "trigger"
                     export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
 
                     echo "Setup kubeconfig for $CLUSTER_NAME"
@@ -158,7 +159,7 @@ jobs:
           - get: cloud-platform-infrastructure-image
           - get: keyval
             passed:
-              - name
+              - trigger
       - task: destroy-test-cluster
         image: cloud-platform-infrastructure-image
         config:
@@ -174,7 +175,7 @@ jobs:
             args:
               - -c
               - |
-                #  This will export cluster name info from the previous job create-cluster-run-tests
+                #  This will export cluster name info from the "trigger" job
                 export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
 
                 mkdir ${HOME}/.aws


### PR DESCRIPTION
a new `cloud-platform` subcommand exists called `cluster create`. This allows the caller to build a cloud-platform eks cluster with all the components necessary for it to be functional. This commit adds a new pipeline that will eventually supercede the current Ruby script.
