### PR TITLE
Increase minutes to look for PRs

### DIFF
--- a/pipelines/manager/main/environments-live-2.yaml
+++ b/pipelines/manager/main/environments-live-2.yaml
@@ -134,7 +134,8 @@ jobs:
                   --skip-version-check \
                   --all-namespaces \
                   --cluster $PIPELINE_CLUSTER \
-                  --kubecfg $KUBECONFIG
+                  --kubecfg $KUBECONFIG \
+                  --minutes 5
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
Increasing the minutes as there is delay in between merging a commit in git and running the command.

The checks are done every minute and it takes another 2 minutes to get tools image and to start the apply command. By the time, the command is run, the commit time is past 1 minute so the PRs are missed to apply. This gives a safeguard of applying all PRs that are merged past 5 minutes. 

The pipelines are run in serial, so wont be any overlapping of applying a namespace by 2 runs simultaneously. And for terraform resources, there is also state lock.