### PR TITLE
Revert "Remove infrastructure pipelines until the 1.22 upgrade is complete"

### DIFF
--- a/pipelines/manager/main/infrastructure-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-live-2.yaml
@@ -1,0 +1,229 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG: /tmp/kubeconfig
+  KUBECONFIG_CLUSTER_NAME: "live-2"
+
+auth0: &AUTH0_CONF
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+  
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: "#lower-priority-alarms"
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  footer: concourse.cloud-platform.service.justice.gov.uk/
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: "0.23.0"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+resources:
+  - name: cloud-platform-tools
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-tools
+      tag: "2.2.4"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      disable_forks: true
+      ignore_drafts: false
+      base_branch: main
+      repository: ministryofjustice/cloud-platform-infrastructure
+      access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths: 
+        - terraform/aws-accounts/cloud-platform-aws/vpc/eks/**/*
+  - name: cloud-platform-infrastructure-repo
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+      branch: main
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths: 
+        - terraform/aws-accounts/cloud-platform-aws/vpc/eks/**/*
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-hook-id))
+
+groups:
+  - name: infrastructure-live-2
+    jobs:
+      - terraform-plan
+      - terraform-apply
+
+jobs:
+  - name: terraform-plan
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: pull-request
+            trigger: true
+            version: every
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+          base_context: infrastructure-live-2
+          context: plan
+      - in_parallel:
+          - task: execute-cluster-plan
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                args:
+                  - -c
+                  - |
+                    (
+                      aws eks --region eu-west-2 update-kubeconfig --name $KUBECONFIG_CLUSTER_NAME
+                    )
+                    terraform init
+                    terraform workspace select $KUBECONFIG_CLUSTER_NAME
+                    terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+          - task: execute-components-plan
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                args:
+                  - -c
+                  - |
+                    (
+                    aws eks --region eu-west-2 update-kubeconfig --name $KUBECONFIG_CLUSTER_NAME
+                    )
+                    terraform init
+                    terraform workspace select $KUBECONFIG_CLUSTER_NAME
+                    terraform plan -input=false -detailed-exitcode | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-live-2
+            context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-live-2
+            context: plan
+
+  - name: terraform-apply
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: cloud-platform-infrastructure-repo
+            trigger: true
+      - in_parallel:
+          - task: execute-cluster-apply
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                args:
+                  - -c
+                  - |
+                    (
+                    aws eks --region eu-west-2 update-kubeconfig --name $KUBECONFIG_CLUSTER_NAME
+                    )
+
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select $KUBECONFIG_CLUSTER_NAME
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+          - task: execute-components-apply
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                args:
+                  - -c
+                  - |
+                    (
+                    aws eks --region eu-west-2 update-kubeconfig --name $KUBECONFIG_CLUSTER_NAME
+                    )
+
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select $KUBECONFIG_CLUSTER_NAME
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -1,0 +1,233 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+  KUBECONFIG_S3_KEY: kubeconfig
+  KUBECONFIG: /tmp/kubeconfig
+
+auth0: &AUTH0_CONF
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: "#lower-priority-alarms"
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  footer: concourse.cloud-platform.service.justice.gov.uk/
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: "0.23.0"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+resources:
+  - name: cloud-platform-tools
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-tools
+      tag: "2.2.4"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      disable_forks: true
+      ignore_drafts: false
+      base_branch: main
+      repository: ministryofjustice/cloud-platform-infrastructure
+      access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+  - name: cloud-platform-infrastructure-repo
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+      branch: main
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths: 
+        - terraform/aws-accounts/cloud-platform-aws/vpc/eks/**/*
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-hook-id))
+
+groups:
+  - name: infrastructure-live
+    jobs:
+      - terraform-plan
+      - terraform-apply
+
+jobs:
+  - name: terraform-plan
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: pull-request
+            trigger: true
+            version: every
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+          base_context: infrastructure-live
+          context: plan
+      - in_parallel:
+          - task: execute-cluster-plan
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                args:
+                  - -c
+                  - |
+                    (
+                      aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                      kubectl config use-context live.cloud-platform.service.justice.gov.uk
+                    )
+                    terraform init
+                    terraform workspace select live
+                    terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+          - task: execute-components-plan
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                args:
+                  - -c
+                  - |
+                    (
+                    aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                    kubectl config use-context live.cloud-platform.service.justice.gov.uk
+                    )
+                    terraform init
+                    terraform workspace select live
+                    terraform plan -input=false -detailed-exitcode | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-live
+            context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-live
+            context: plan
+
+  - name: terraform-apply
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: cloud-platform-infrastructure-repo
+            trigger: true
+            version: every
+      - in_parallel:
+          - task: execute-cluster-apply
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                args:
+                  - -c
+                  - |
+                    (
+                    aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                    kubectl config use-context live.cloud-platform.service.justice.gov.uk
+                    )
+
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select live
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+          - task: execute-components-apply
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                args:
+                  - -c
+                  - |
+                    (
+                    aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                    kubectl config use-context live.cloud-platform.service.justice.gov.uk
+                    )
+
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select live
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -1,0 +1,233 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+kube-config: &KUBECONFIG_PARAMS
+  KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
+  KUBECONFIG_S3_KEY: kubeconfig
+  KUBECONFIG: /tmp/kubeconfig
+
+auth0: &AUTH0_CONF
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: "#lower-priority-alarms"
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  footer: concourse.cloud-platform.service.justice.gov.uk/
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: "0.23.0"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+resources:
+  - name: cloud-platform-tools
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-tools
+      tag: "2.2.4"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      disable_forks: true
+      ignore_drafts: false
+      base_branch: main
+      repository: ministryofjustice/cloud-platform-infrastructure
+      access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths: 
+        - terraform/aws-accounts/cloud-platform-aws/vpc/eks/**/*
+  - name: cloud-platform-infrastructure-repo
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+      branch: main
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths: 
+        - terraform/aws-accounts/cloud-platform-aws/vpc/eks/**/*
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-hook-id))
+
+groups:
+  - name: infrastructure-manager
+    jobs:
+      - terraform-plan
+      - terraform-apply
+
+jobs:
+  - name: terraform-plan
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: pull-request
+            trigger: true
+            version: every
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+          base_context: infrastructure-manager
+          context: plan
+      - in_parallel:
+          - task: execute-cluster-plan
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                args:
+                  - -c
+                  - |
+                    (
+                      aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                      kubectl config use-context manager.cloud-platform.service.justice.gov.uk
+                    )
+                    terraform init
+                    terraform workspace select manager
+                    terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+          - task: execute-components-plan
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                args:
+                  - -c
+                  - |
+                    (
+                    aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                    kubectl config use-context manager.cloud-platform.service.justice.gov.uk
+                    )
+                    terraform init
+                    terraform workspace select manager
+                    terraform plan -input=false -detailed-exitcode | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-manager
+            context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-manager
+            context: plan
+
+  - name: terraform-apply
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: cloud-platform-infrastructure-repo
+            trigger: true
+      - in_parallel:
+          - task: execute-cluster-apply
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/eks
+                args:
+                  - -c
+                  - |
+                    (
+                    aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                    kubectl config use-context manager.cloud-platform.service.justice.gov.uk
+                    )
+
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select manager
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+
+          - task: execute-components-apply
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: [*AUTH0_CONF, *AWS_CREDENTIALS, *KUBECONFIG_PARAMS]
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components
+                args:
+                  - -c
+                  - |
+                    (
+                    aws s3 cp s3://cloud-platform-concourse-kubeconfig/kubeconfig /tmp/kubeconfig
+                    kubectl config use-context manager.cloud-platform.service.justice.gov.uk
+                    )
+
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select manager
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-terraform-concourse#171

Now the k8s 1.22 upgrade is complete. All code changes are merged to main, enable the infrastructure pipelines for manager,live-2 and live