### PR TITLE
Rename live - live-1 and add live-2 vpc pipeline

### DIFF
--- a/pipelines/manager/main/infrastructure-vpc-live-1.yaml
+++ b/pipelines/manager/main/infrastructure-vpc-live-1.yaml
@@ -58,7 +58,7 @@ resources:
       url: https://hooks.slack.com/services/((slack-hook-id))
 
 groups:
-  - name: infrastructure-cloud-platform-aws-vpc
+  - name: infrastructure-cloud-platform-aws-vpc-live-1
     jobs:
       - terraform-plan
       - terraform-apply
@@ -75,7 +75,7 @@ jobs:
         params:
           path: pull-request
           status: pending
-          base_context: infrastructure-cloud-platform-aws-vpc
+          base_context: infrastructure-cloud-platform-aws-vpc-live-1
           context: plan
       - in_parallel:
           - task: execute-cloud-platform-aws-vpc
@@ -106,14 +106,14 @@ jobs:
           params:
             path: pull-request
             status: failure
-            base_context: infrastructure-cloud-platform-aws-vpc
+            base_context: infrastructure-cloud-platform-aws-vpc-live-1
             context: plan
         on_success:
           put: pull-request
           params:
             path: pull-request
             status: success
-            base_context: infrastructure-cloud-platform-aws-vpc
+            base_context: infrastructure-cloud-platform-aws-vpc-live-1
             context: plan
 
   - name: terraform-apply

--- a/pipelines/manager/main/infrastructure-vpc-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-vpc-live-2.yaml
@@ -1,0 +1,157 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+
+slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+  channel: "#lower-priority-alarms"
+slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+  fallback: "Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title: "$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME"
+  title_link: "https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  footer: concourse.cloud-platform.service.justice.gov.uk/
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: "0.23.0"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+resources:
+  - name: cloud-platform-tools
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-tools
+      tag: "2.2.4"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+  - name: pull-request
+    type: pull-request
+    check_every: 1m
+    source:
+      disable_forks: true
+      ignore_drafts: false
+      base_branch: main
+      repository: ministryofjustice/cloud-platform-infrastructure
+      access_token: ((cloud-platform-infrastructure-pr-git-access-token))
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths:
+        - terraform/aws-accounts/cloud-platform-aws/vpc/**
+  - name: cloud-platform-infrastructure-repo
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+      branch: main
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+      paths: 
+        - terraform/aws-accounts/cloud-platform-aws/vpc/**
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack-hook-id))
+
+groups:
+  - name: infrastructure-cloud-platform-aws-vpc-live-2
+    jobs:
+      - terraform-plan
+      - terraform-apply
+
+jobs:
+  - name: terraform-plan
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: pull-request
+            trigger: true
+      - put: pull-request
+        params:
+          path: pull-request
+          status: pending
+          base_context: infrastructure-cloud-platform-aws-vpc-live-2
+          context: plan
+      - in_parallel:
+          - task: execute-cloud-platform-aws-vpc
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: *AWS_CREDENTIALS
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc
+                args:
+                  - -c
+                  - |
+                    terraform init
+                    terraform workspace select live-2
+                    terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+        on_failure:
+          put: pull-request
+          params:
+            path: pull-request
+            status: failure
+            base_context: infrastructure-cloud-platform-aws-vpc-live-2
+            context: plan
+        on_success:
+          put: pull-request
+          params:
+            path: pull-request
+            status: success
+            base_context: infrastructure-cloud-platform-aws-vpc-live-2
+            context: plan
+
+  - name: terraform-apply
+    serial: true
+    plan:
+      - in_parallel:
+          - get: cloud-platform-tools
+          - get: cloud-platform-infrastructure-repo
+            trigger: true
+            version: every
+      - in_parallel:
+          - task: execute-cloud-platform-aws-vpc
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: *AWS_CREDENTIALS
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc
+                args:
+                  - -c
+                  - |
+                    terraform init -backend-config="dynamodb_table=cloud-platform-terraform-state"
+                    terraform workspace select live-2
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+        on_failure:
+          put: slack-alert
+          params:
+            <<: *SLACK_NOTIFICATION_DEFAULTS
+            attachments:
+              - color: "danger"
+                <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
This PR renames infrastructure-vpc pipeline to infrastructure-vpc-live-1 and add a new pipeline for terraform plan/apply for vpc live-2