### PR TITLE
Refactor to meet standardised Terraform structure and remove legacy syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   # This is the list of Route53 Hosted Zones in the DSD account that
   # cert-manager and external-dns will be given access to.
   live_workspace = "manager"
-  rds_name       = var.is_prod ? "ci" : "${terraform.workspace}-concourse"
+  # rds_name       = var.is_prod ? "ci" : "${terraform.workspace}-concourse"
   live_domain    = "cloud-platform.service.justice.gov.uk"
 }
 
@@ -388,7 +388,7 @@ resource "kubernetes_namespace" "concourse_main" {
   }
 }
 
-// Rolebinding between concourse-web serviveaccount and ClusterRole concourse-web to enable pipelines access secrets from namespace concourse-main
+# Rolebinding between concourse-web serviveaccount and ClusterRole concourse-web to enable pipelines access secrets from namespace concourse-main
 resource "kubernetes_role_binding" "concourse_web" {
   metadata {
     name      = "concourse-web-rolebinding"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ locals {
   # This is the list of Route53 Hosted Zones in the DSD account that
   # cert-manager and external-dns will be given access to.
   live_workspace = "manager"
-  # rds_name       = var.is_prod ? "ci" : "${terraform.workspace}-concourse"
   live_domain    = "cloud-platform.service.justice.gov.uk"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,17 +35,6 @@ variable "tf_provider_auth0_client_secret" {
   description = "Client Secret (prod) for auth0, it is used by divergence pipelines"
 }
 
-variable "cluster_name" {
-  default     = ""
-  description = "The cluster name where is going to be deployed"
-}
-
-variable "is_prod" {
-  type        = bool
-  default     = false
-  description = "Is it production CI?"
-}
-
 variable "dependence_prometheus" {
   description = "Prometheus module dependence - it is required in order to use this module."
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,23 +2,28 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = ">=4.24.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.6.0"
+      version = ">=2.6.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
+      version = ">=2.12.1"
     }
     kubectl = {
       source = "gavinbunney/kubectl"
+      version = ">=1.13.2"
     }
     random = {
       source = "hashicorp/random"
+      version = ">=3.4.3"
     }
     tls = {
       source = "hashicorp/tls"
+      version = ">=4.0.3"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }


### PR DESCRIPTION
This PR:

- removes the unused `rds_name` local variable
- switches the legacy `//` comment to a `#` comment
- removes the unused `cluster_name` and `is_prod` variables
- pins minimum Terraform and Terraform provider versions

(this PR is a no-op)