### PR TITLE
Add IAM Access Analyzer permissions to global_account_policy

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -621,6 +621,17 @@ data "aws_iam_policy_document" "global_account_policy" {
     ]
   }
 
+  # Allows the creation and management of IAM Access Analyzer
+  statement {
+    actions = [
+      "access-analyzer:*"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
   /* End of permissions for concourse pipeline cloud-platform-aws account */
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.24.0"
     }
     helm = {
@@ -9,19 +9,19 @@ terraform {
       version = ">=2.6.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = ">=2.12.1"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
       version = ">=1.13.2"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">=3.4.3"
     }
     tls = {
-      source = "hashicorp/tls"
+      source  = "hashicorp/tls"
       version = ">=4.0.3"
     }
   }


### PR DESCRIPTION
This PR should fix the failing Concourse job to apply [this PR](https://github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines/commit/665a9e98ca7bc4c57ff6db4b188029a00e67e566).