### PR TITLE
Remove path and format yaml

### DIFF
--- a/pipelines/manager/main/environments-live-2.yaml
+++ b/pipelines/manager/main/environments-live-2.yaml
@@ -60,8 +60,6 @@ resources:
       base_branch: main
       repository: ministryofjustice/cloud-platform-environments
       access_token: ((cloud-platform-environments-pr-git-access-token))
-      paths:
-        - namespaces/live-2.cloud-platform.service.justice.gov.uk
   - name: slack-alert
     type: slack-notification
     source:
@@ -147,9 +145,9 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: cloud-platform-environments
-          trigger: true
-        - get: cloud-platform-cli
+          - get: cloud-platform-environments
+            trigger: true
+          - get: cloud-platform-cli
       - task: apply-namespace-changes
         timeout: 1h
         image: cloud-platform-cli
@@ -240,10 +238,10 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: cloud-platform-environments-live-2-pull-requests
-          trigger: true
-          version: every
-        - get: cloud-platform-cli
+          - get: cloud-platform-environments-live-2-pull-requests
+            trigger: true
+            version: every
+          - get: cloud-platform-cli
       - put: cloud-platform-environments-live-2-pull-requests
         params:
           path: cloud-platform-environments-live-2-pull-requests


### PR DESCRIPTION
triggering condition(len(path) > 0) in the pr-github-resource performs an inefficient search of all PRs closed and open in a repository. This quickly eats up our finite GitHub API calls.
