### PR TITLE
Bump cli to 1.22.12

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -63,7 +63,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.22.11"
+    tag: "1.22.12"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-environments-live-pull-requests-merged


### PR DESCRIPTION
Bump cli image to 1.22.12 which has fix to not error when resources folder doesnot exists in any namespace
