### PR TITLE
Use latest cli with terraform 1.2.5 on plan-manually job

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -66,6 +66,13 @@ resources:
     tag: "1.22.12"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
+- name: cloud-platform-cli-tf-upg
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-cli
+    tag: "1.24.0"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-environments-live-pull-requests-merged
   type: pull-request
   check_every: 1m
@@ -277,10 +284,10 @@ jobs:
     plan:
       - get: cloud-platform-environments
         trigger: false
-      - get: cloud-platform-cli
+      - get: cloud-platform-cli-tf-upg
       - task: plan-environments-manually
         timeout: 1h
-        image: cloud-platform-cli
+        image: cloud-platform-cli-tf-upg
         config:
           platform: linux
           inputs:


### PR DESCRIPTION
This is to test the cli binary with terraform version 1.2.5 on environments to perform manual plan