### PR TITLE
upgrade tools image to 2.3.0 for live/2/manager infra pipelines

### DIFF
--- a/pipelines/manager/main/infrastructure-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-live-2.yaml
@@ -38,7 +38,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.2.4"
+      tag: "2.3.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -39,7 +39,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.2.4"
+      tag: "2.3.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -39,7 +39,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.2.4"
+      tag: "2.3.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request


### PR DESCRIPTION
This PR upgrades cloud-platform-tools image to v2.3.0 for enabling terraform upgrade in cloud-platform-infrastructure pipelines