### PR TITLE
update environments-live cli image

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -63,7 +63,7 @@ resources:
   type: registry-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.24.5"
+    tag: "1.26.2"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-environments-live-pull-requests-merged


### PR DESCRIPTION
This PR bumps environments-live pipeline CLI version for relaxing terraform output redaction rules.