### PR TITLE
Increase timout for apply-live job

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -117,13 +117,13 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-120m
+        - get: every-240m
           trigger: true
         - get: cloud-platform-environments
           trigger: false
         - get: cloud-platform-cli
       - task: apply-environments
-        timeout: 4h
+        timeout: 5h
         image: cloud-platform-cli
         config:
           platform: linux


### PR DESCRIPTION
The apply-live pipeline is getting `timeout exceeded` error. As the number of namespaces have increased recently 1 full run is taking more than 4 hours to finish.