### PR TITLE
Bump cli image on all pipelines

### DIFF
--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -24,7 +24,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.26.8"
+      tag: "1.28.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -17,7 +17,8 @@ apply-plan-pipline: &APPLY_PLAN_PIPELINE
   PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
   PIPELINE_STATE_REGION: "eu-west-1" # The region of the state bucket
   # the variables prefixed with PIPELINE_ are used by the apply script
-  PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
+  PIPELINE_CLUSTER: arn:aws:eks:eu-west-2:754256621582:cluster/live
+  PIPELINE_CLUSTER_DIR: live.cloud-platform.service.justice.gov.uk
   PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
 
 terraform-shared: &TERRAFORM_SHARED
@@ -63,7 +64,7 @@ resources:
   type: registry-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.26.8"
+    tag: "1.28.0"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-environments-live-pull-requests-merged
@@ -153,6 +154,7 @@ jobs:
                   --all-namespaces \
                   --enable-apply-skip \
                   --cluster $PIPELINE_CLUSTER \
+                  --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG
         on_failure:
           put: slack-alert
@@ -206,6 +208,7 @@ jobs:
                 cloud-platform environment apply \
                   --skip-version-check \
                   --cluster $PIPELINE_CLUSTER \
+                  --clusterdir $PIPELINE_CLUSTER_DIR \
                   --prNumber $PR \
                   --kubecfg $KUBECONFIG
         on_success:
@@ -263,6 +266,7 @@ jobs:
                   --skip-version-check \
                   --namespace $NAMESPACE \
                   --cluster $PIPELINE_CLUSTER \
+                  --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG
         on_failure:
           put: slack-alert
@@ -310,6 +314,7 @@ jobs:
                   --skip-version-check \
                   --prNumber $PR \
                   --cluster $PIPELINE_CLUSTER \
+                  --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG
         on_failure:
           put: slack-alert
@@ -362,6 +367,7 @@ jobs:
                   --skip-version-check \
                   --prNumber $PR \
                   --cluster $PIPELINE_CLUSTER \
+                  --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG
         on_failure:
             put: cloud-platform-environments-live-pull-requests
@@ -426,46 +432,59 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: cloud-platform-environments
+        - get: cloud-platform-environments-live-pull-requests-merged
           trigger: true
-        - get: pipeline-tools-image
+          version: every
+        - get: cloud-platform-cli
+      - put: cloud-platform-environments-live-pull-requests-merged
+        params:
+          path: cloud-platform-environments-live-pull-requests-merged
+          status: pending
+          comment: "Namespace deletion detected. Destroying namespace in the build: https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
       - task: destroy-deleted-namespaces
-        image: pipeline-tools-image
+        timeout: 1h
+        image: cloud-platform-cli
         config:
           platform: linux
           inputs:
-            - name: cloud-platform-environments
+            - name: cloud-platform-environments-live-pull-requests-merged
           params:
-            AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
-            AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
-            KUBECONFIG_S3_BUCKET: cloud-platform-concourse-kubeconfig
-            KUBECONFIG_S3_KEY: kubeconfig
-            KUBE_CONFIG: /tmp/kubeconfig
-            KUBE_CONFIG_PATH: /tmp/kubeconfig
-            KUBE_CTX: live.cloud-platform.service.justice.gov.uk
-            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
-            PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
-            # PIPELINE_CLUSTER_STATE is s3 repo where namespace terraform state is stored currently.
-            PIPELINE_CLUSTER_STATE: live-1.cloud-platform.service.justice.gov.uk
-            PIPELINE_STATE_REGION: "eu-west-1"
-            SLACK_WEBHOOK: ((slack-hook-id))
-            PIPELINE_CLUSTER: live.cloud-platform.service.justice.gov.uk
-            PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
-            # the variable cluster_name provided here as required when running terraform init
-            TF_VAR_github_owner: "ministryofjustice"
-            TF_VAR_github_token: ((github-actions-secrets-token.token))
-            TF_VAR_vpc_name: "live-1"
-            TF_VAR_eks_cluster_name: "live"
-            TF_VAR_kubernetes_cluster: "DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com"
+            <<:
+              [
+                *AWS_CREDENTIALS,
+                *KUBECONFIG_PARAMS,
+                *PINGDOM_PARAMS,
+                *APPLY_PLAN_PIPELINE,
+                *TERRAFORM_SHARED,
+              ]
           run:
-            path: /bin/sh
-            dir: cloud-platform-environments
+            path: /bin/bash
+            dir: cloud-platform-environments-live-pull-requests-merged
             args:
               - -c
               - |
-                bundle install --without development test
-                ./bin/auto-delete-namespace.rb
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                (
+                  aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
+                )
+                export PR=$(cat .git/resource/pr)
+                echo $PR
+                cloud-platform environment destroy \
+                  --skip-version-check \
+                  --cluster $PIPELINE_CLUSTER \
+                  --clusterdir $PIPELINE_CLUSTER_DIR \
+                  --prNumber $PR \
+                  --kubecfg $KUBECONFIG
+        on_success:
+          put: cloud-platform-environments-live-pull-requests-merged
+          params:
+            path: cloud-platform-environments-live-pull-requests-merged
+            status: success
         on_failure:
+          put: cloud-platform-environments-live-pull-requests-merged
+          params:
+            path: cloud-platform-environments-live-pull-requests-merged
+            status: failure
           put: slack-alert
           params:
             <<: *SLACK_NOTIFICATION_DEFAULTS

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -21,7 +21,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.26.8"
+      tag: "1.28.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: go-delete-snapshots-image


### PR DESCRIPTION
This PR bumps the cli image to 1.28.0
The latest cli has the `cloud-platform environment delete` command which is used by destroy-deleted-namespaces pipeline.

The pipeline also includes the PIPELINE_CLUSTER_DIR which replaces PIPELINE_CLUSTER in order to differentiate the cluster context with the folder structure of the environments repo