### PR TITLE
feat: 🎸 add dedicated delete test cluster pipeline, remove old

### DIFF
--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -69,7 +69,6 @@ groups:
       - trigger
       - create
       - test
-      - destroy
 
 jobs:
   - name: trigger
@@ -177,37 +176,3 @@ jobs:
 
             on_failure: *slack_failure_notification
 
-  - name: destroy
-    serial: true
-    plan:
-      - in_parallel:
-          - get: cloud-platform-infrastructure-repository
-          - get: cloud-platform-cli-image
-          - get: keyval
-            passed:
-              - trigger
-      - task: destroy-test-cluster
-        image: cloud-platform-cli-image
-        config:
-          platform: linux
-          params:
-            <<: [*aws_params, *auth0_params]
-          inputs:
-            - name: cloud-platform-infrastructure-repository
-              path: ./
-            - name: keyval
-          run:
-            path: /bin/bash
-            args:
-              - -c
-              - |
-                set -e
-                #  This will export cluster name info from the "trigger" job
-                export $(cat keyval/keyval.properties | grep CLUSTER_NAME )
-
-                mkdir ${HOME}/.aws
-                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
-                echo "Executing: cluster delete $CLUSTER_NAME"
-                cloud-platform cluster delete --name $CLUSTER_NAME --dry-run=false --skip-version-check
-
-        on_failure: *slack_failure_notification

--- a/pipelines/manager/main/delete-cluster.yaml
+++ b/pipelines/manager/main/delete-cluster.yaml
@@ -1,0 +1,61 @@
+resources:
+  - name: cloud-platform-infrastructure-repository
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/cloud-platform-infrastructure.git
+      branch: main
+      git_crypt_key: ((cloud-platform-infrastructure-git-crypt.key))
+
+  - name: cloud-platform-cli-image
+    type: registry-image
+    source:
+      repository: ministryofjustice/cloud-platform-cli
+      tag: "1.28.1"
+      username: ((ministryofjustice-dockerhub.dockerhub_username))
+      password: ((ministryofjustice-dockerhub.dockerhub_password))
+
+aws_params: &aws_params
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+  AWS_PROFILE: moj-cp
+
+auth0_params: &auth0_params
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+
+groups:
+  - name: delete-cluster
+    jobs:
+      - delete
+
+jobs:
+  - name: delete
+    max_in_flight: 5
+    plan:
+      - in_parallel:
+          - get: cloud-platform-infrastructure-repository
+          - get: cloud-platform-cli-image
+      - task: delete-cluster
+        image: cloud-platform-cli-image
+        config:
+          platform: linux
+          params:
+            <<: [*aws_params, *auth0_params]
+            CLUSTER_NAME: ((cluster_name))
+          inputs:
+            - name: cloud-platform-infrastructure-repository
+          run:
+            dir: cloud-platform-infrastructure-repository
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                set -e
+
+                mkdir ${HOME}/.aws
+                echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
+                echo "Executing: cluster delete $CLUSTER_NAME"
+                cloud-platform cluster delete --name $CLUSTER_NAME --dry-run=false --skip-version-check
+


### PR DESCRIPTION
This is the first step to creating a better workflow around deleting test clusters. This step removes the need to edit or "hijack" other pipelines, this makes a dedicated pipeline that handles deleting clusters.

The next step will wrap the fly commands below into our cli reducing overheads for devs

note: because we are leaning on the cli command we are protected against accidentally deleting `live*` or `manager`

```
fly --target $TEST_CONCOURSE_NAME login --team-name main --concourse-url https://concourse.apps.$CLUSTER_NAME.cloud-platform.service.justice.gov.uk/
fly -t $TEST_CONCOURSE_NAME set-pipeline -p delete-cluster -c pipelines/manager/main/delete-cluster.yaml -v cluster_name=$CP-BLAH-BLAH
fly -t $TEST_CONCOURSE_NAME unpause-pipeline -p delete-cluster # only need to do this when first creating the pipeline
# -w flag will output the concourse job output to your terminal
fly -t $TEST_CONCOURSE_NAME trigger-job -j delete-cluster/delete -w
```