### PR TITLE
increase apply-namespace-changes-live timeout to 2hrs

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -178,7 +178,7 @@ jobs:
           status: pending
           comment: " Your PR is applying in the build: https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
       - task: apply-namespace-changes
-        timeout: 1h
+        timeout: 2h
         image: cloud-platform-cli
         config:
           platform: linux


### PR DESCRIPTION
to cover long running opensearch upgrade jobs