### PR TITLE
Add GetUserPolicy permission to all iam users

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -486,7 +486,8 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
       "iam:ListPolicies",
-      "iam:GetInstanceProfile"
+      "iam:GetInstanceProfile",
+      "iam:GetUserPolicy",
     ]
 
     resources = [


### PR DESCRIPTION
Concourse pipeline fails with 
```reading IAM User Policy (ecr-user-XXXX:ecr-read-write): AccessDenied: User: arn:aws:iam::XXX:user/cloud-platform/manager-concourse is not authorized to perform: iam:GetUserPolicy on resource: user ecr-user-XXXX because no identity-based policy allows the iam:GetUserPolicy action```