### PR TITLE
🔥 Removing psp from concourse

### DIFF
--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -162,12 +162,6 @@ web:
 ## Concourse Workers, see https://concourse-ci.org/concourse-worker.html
 ##
 
-# podSecurityPolicy:
-#   ## Create podSecurityPolicy objects for concourse. Set this to false if
-#   ## objects are not needed, or if they are managed outside helm.
-#   ##
-#   create: true
-
 worker:
 
   ## Number of replicas.


### PR DESCRIPTION
Removing PSP objects from concourse as part of the PSP > PSA migration.