### PR TITLE
Add DetachUserPolicy needed when renaming iam users

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -32,6 +32,7 @@ data "aws_iam_policy_document" "policy" {
       "iam:PutUserPolicy",
       "iam:GetUserPolicy",
       "iam:DeleteUserPolicy",
+      "iam:DetachUserPolicy",
       "iam:ListGroupsForUser",
       "iam:PutUserPermissionsBoundary",
       "iam:GetPolicy",


### PR DESCRIPTION
To fix concourse failure: AccessDenied: User: XXX../cloud-platform/manager-concourse is not authorized to perform: iam:DetachUserPolicy on resource: user alfresco_user_poc 