### PR TITLE
:wrench: adding transit-gateway terraform to live-1 VPC pipeline

### DIFF
--- a/pipelines/manager/main/infrastructure-vpc-live-1.yaml
+++ b/pipelines/manager/main/infrastructure-vpc-live-1.yaml
@@ -101,6 +101,29 @@ jobs:
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
                     if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+          - task: execute-cloud-platform-aws-vpc-transit-gateway
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: *AWS_CREDENTIALS
+              inputs:
+                - name: pull-request
+              run:
+                path: /bin/bash
+                dir: pull-request/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway
+                args:
+                  - -c
+                  - |
+                    terraform init
+                    terraform workspace select default
+                    terraform plan -input=false -detailed-exitcode -lock-timeout=3m | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi                    
         on_failure:
           put: pull-request
           params:
@@ -148,6 +171,29 @@ jobs:
                       -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
                       -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
                     if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi
+          - task: execute-cloud-platform-aws-vpc-transit-gateway
+            image: cloud-platform-tools
+            config:
+              platform: linux
+              params:
+                <<: *AWS_CREDENTIALS
+              inputs:
+                - name: cloud-platform-infrastructure-repo
+              run:
+                path: /bin/bash
+                dir: cloud-platform-infrastructure-repo/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway
+                args:
+                  - -c
+                  - |
+                    terraform init
+                    terraform workspace select default
+                    terraform apply -input=false -lock-timeout=3m -auto-approve | \
+                      sed -e 's/AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/$AWS_SECRET_ACCESS_KEY".*/<REDACTED>/g' \
+                      -e 's/$AWS_ACCESS_KEY_ID".*/<REDACTED>/g' \
+                      -e 's/\[id=.*\]/\[id=<REDACTED>\]/g'
+                    if [ ${PIPESTATUS[0]} -eq 1 ]; then exit 1; else exit 0; fi                    
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
This will PR will add a task to the `infrastructure-vpc-live-1` Concourse pipeline which runs terraform plan and apply the `transit-gateway` folder level.