### PR TITLE
modified job live-orphaned-namespaces to run daily at 10:00am

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -94,9 +94,9 @@ resources:
   - name: reminder-schedule-am-daily
     type: time
     source:
-      days: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
+      days: [Monday, Tuesday, Wednesday, Thursday, Friday]
       start: 10:00 AM
-      stop: 10:02 AM
+      stop: 11:00 AM
       location: Europe/London
 
 groups:


### PR DESCRIPTION
Changed the job to run at 10:00 daily, instead of the current time which is 19:14
