### PR TITLE
Remove fast option from cluster create

### DIFF
--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -135,7 +135,7 @@ jobs:
                 mkdir ${HOME}/.aws
                 echo "[moj-cp]" >> ${HOME}/.aws/credentials # This forces you to have profiles
 
-                cloud-platform cluster create --name $CLUSTER_NAME --skip-version-check --fast
+                cloud-platform cluster create --name $CLUSTER_NAME --skip-version-check
 
         on_failure: *slack_failure_notification
 


### PR DESCRIPTION
The re-adds creation of the OIDC connector. It adds about 10 minutes to create cluster but saves manually creating the resource when working with a test cluster.