### PR TITLE
Bump tools-image to latest version 2.9.5

### DIFF
--- a/pipelines/manager/main/bootstrap.yaml
+++ b/pipelines/manager/main/bootstrap.yaml
@@ -13,7 +13,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-tools
-    tag: "2.9.4"
+    tag: "2.9.5"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -39,7 +39,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-infrastructure
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/custom-cluster.yaml
+++ b/pipelines/manager/main/custom-cluster.yaml
@@ -35,7 +35,7 @@ resources:
     type: docker-image
     source:
       repository: registry.hub.docker.com/ministryofjustice/cloud-platform-infrastructure
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -18,7 +18,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 
@@ -34,7 +34,7 @@ resources:
     type: docker-image
     source:
       repository: registry.hub.docker.com/ministryofjustice/cloud-platform-infrastructure
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -71,7 +71,7 @@ resources:
   type: docker-image
   source:
     repository: ministryofjustice/cloud-platform-pipeline-tools
-    tag: "2.9.4"
+    tag: "2.9.5"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-cli

--- a/pipelines/manager/main/infrastructure-account.yaml
+++ b/pipelines/manager/main/infrastructure-account.yaml
@@ -39,7 +39,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-global-resources.yaml
+++ b/pipelines/manager/main/infrastructure-global-resources.yaml
@@ -35,7 +35,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-vpc-live-1.yaml
+++ b/pipelines/manager/main/infrastructure-vpc-live-1.yaml
@@ -29,7 +29,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-vpc-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-vpc-live-2.yaml
@@ -29,7 +29,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -41,7 +41,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: slack-alert

--- a/pipelines/manager/main/migrate-module.yaml
+++ b/pipelines/manager/main/migrate-module.yaml
@@ -3,7 +3,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -33,7 +33,7 @@ resources:
     type: docker-image
     source:
       repository: registry.hub.docker.com/ministryofjustice/cloud-platform-infrastructure
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: orphaned-namespace-checker-image

--- a/pipelines/manager/main/vulnerability-report.yaml
+++ b/pipelines/manager/main/vulnerability-report.yaml
@@ -3,7 +3,7 @@ resources:
     type: docker-image
     source:
       repository: ministryofjustice/cloud-platform-tools
-      tag: "2.9.4"
+      tag: "2.9.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: cloud-platform-infrastructure-repo


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-tools-image/releases/tag/2.9.5

Closes: https://github.com/ministryofjustice/cloud-platform/issues/5711