### PR TITLE
 ⬆️ bump orphaned_namespace_checker image

### DIFF
--- a/pipelines/manager/main/reporting.yaml
+++ b/pipelines/manager/main/reporting.yaml
@@ -40,7 +40,7 @@ resources:
     type: docker-image
     source:
       repository: registry.hub.docker.com/ministryofjustice/orphaned-namespace-checker
-      tag: 3.3.1
+      tag: 3.3.2
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: cloud-platform-tools-terraform


### PR DESCRIPTION
This PR bumps the orphaned_namespace_checker image. The image features a fix for the [live-orphaned-namespaces report/alert discrepancy](https://github.com/ministryofjustice/cloud-platform/issues/5765) issue

Details of fix can be found [here](https://github.com/ministryofjustice/cloud-platform-environments-checker/pull/62)