### PR TITLE
feat: Update CloudWatch Tagging Permission

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -607,6 +607,8 @@ data "aws_iam_policy_document" "global_account_policy" {
       "cloudwatch:ListTagsForResource",
       "cloudwatch:PutMetricAlarm",
       "cloudwatch:DeleteAlarms",
+      "cloudwatch:TagResource",
+      "cloudwatch:UntagResource",
     ]
 
     resources = [


### PR DESCRIPTION
Fix below error

```
FATA[0063] error running terraform on namespace hmpps-integration-api-dev: unable to apply Terraform: exit status 1

Error: updating tags for CloudWatch Metric Alarm (arn:aws:cloudwatch:eu-west-2:754256621582:alarm:hmpps-integration-api-dev-gateway-4XX-errors): tagging resource (arn:aws:cloudwatch:eu-west-2:754256621582:alarm:hmpps-integration-api-dev-gateway-4XX-errors): AccessDenied: User: arn:aws:iam::754256621582:user/cloud-platform/manager-concourse is not authorized to perform: cloudwatch:TagResource on resource: arn:aws:cloudwatch:eu-west-2:754256621582:alarm:hmpps-integration-api-dev-gateway-4XX-errors because no identity-based policy allows the cloudwatch:TagResource action
	status code: 403, request id: 118f55cc-eee4-4360-853d-c0f60eebaf64

  with aws_cloudwatch_metric_alarm.gateway_4XX_error_rate,
  on api_gateway.tf line 245, in resource "aws_cloudwatch_metric_alarm" "gateway_4XX_error_rate":
 245: resource "aws_cloudwatch_metric_alarm" "gateway_4XX_error_rate" {
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/5795

Relates to ministryofjustice/cloud-platform#5892

