### PR TITLE
:zap:introducing jobs distribution strategy

### DIFF
--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -73,6 +73,10 @@ concourse:
       github:
         enabled: true
 
+    ## Method by which a worker is selected during container placement.
+    ## Possible values: volume-locality | random | fewest-build-containers | limit-active-tasks | limit-active-containers | limit-active-volumes
+    containerPlacementStrategy: fewest-build-containers
+
 
 ## Configuration values for Concourse Web components.
 ## For more information regarding the characteristics of


### PR DESCRIPTION
This PR will ensure Concourse jobs are spread evenly across the workers. The strategy selected is [fewest-build-containers](https://concourse-ci.org/container-placement.html#fewest-build-containers-strategy), whereby it will looks for the worker with the fewest jobs and place the pending job onto there. 

Related to [Concourse worker job distribution fix](https://github.com/ministryofjustice/cloud-platform/issues/5839) issue