### PR TITLE
fix: 🐛 allow node group to be deleted

### DIFF
--- a/pipelines/manager/main/cordon-and-drain-nodes.yaml
+++ b/pipelines/manager/main/cordon-and-drain-nodes.yaml
@@ -82,6 +82,9 @@ jobs:
                   ASG_NAME=$(aws eks --region eu-west-2 describe-nodegroup --cluster-name $KUBECONFIG_CLUSTER_NAME --nodegroup-name $NODE_GROUP_TO_DRAIN  | jq -r ".nodegroup.resources.autoScalingGroups[0].name")
                   aws autoscaling suspend-processes --auto-scaling-group-name $ASG_NAME
 
+                  # needed to allow the node group to be deleted by terraform later
+                  aws autoscaling resume-processes --auto-scaling-group-name $ASG_NAME --scaling-process Terminate
+
                   aws autoscaling create-or-update-tags --tags ResourceId=$ASG_NAME,ResourceType=auto-scaling-group,Key=k8s.io/cluster-autoscaler/enabled,Value=false,PropagateAtLaunch=true
                 }
 


### PR DESCRIPTION
Terraform fails to delete the node group with the following error

```
Error: waiting for EKS Node Group (live:live-def-ng-20240814092yyyyyyyy00f) delete: unexpected state 'DELETE_FAILED', wanted target ''. last error: eks-live-def-ng-202408xxxxxxxxxxxxxf-eac8a81b-d82d-80d0-73b8-cdffc29c54da: AutoScalingGroupInvalidConfiguration: Couldn't terminate instances in ASG as Terminate process is suspended
```