### PR TITLE
chore: 🤖 pass build url to apply live pipelines

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -18,7 +18,7 @@ slack: &SLACK_BOT_PARAMS
 github-token: &GITHUB_PARAMS
   GITHUB_TOKEN: ((github-actions-secrets-token.token))
 
-apply-plan-pipline: &APPLY_PLAN_PIPELINE
+apply-plan-pipeline: &APPLY_PLAN_PIPELINE
   PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
   PIPELINE_STATE_KEY_PREFIX: "cloud-platform-environments/"
   PIPELINE_TERRAFORM_STATE_LOCK_TABLE: "cloud-platform-environments-terraform-lock"
@@ -225,6 +225,11 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
                 )
+
+                BUILD_URL="https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
+                echo $BUILD_URL
+
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
                 cloud-platform environment apply \
                   --skip-version-check \
@@ -234,6 +239,7 @@ jobs:
                   --cluster $PIPELINE_CLUSTER \
                   --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG \
+                  --build-url $BUILD_URL \
                   --is-pipeline true
         on_failure:
           put: slack-alert
@@ -283,6 +289,11 @@ jobs:
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
+
+                BUILD_URL="https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
+                echo $BUILD_URL
+
                 cloud-platform environment apply \
                   --skip-version-check \
                   --batch-apply-index $((1*${BATCHSIZE}))  \
@@ -291,6 +302,7 @@ jobs:
                   --cluster $PIPELINE_CLUSTER \
                   --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG \
+                  --build-url $BUILD_URL \
                   --is-pipeline true
         on_failure:
           put: slack-alert
@@ -340,6 +352,11 @@ jobs:
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
+
+                BUILD_URL="https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
+                echo $BUILD_URL
+
                 cloud-platform environment apply \
                   --skip-version-check \
                   --batch-apply-index $((2*${BATCHSIZE}))  \
@@ -348,6 +365,7 @@ jobs:
                   --cluster $PIPELINE_CLUSTER \
                   --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG \
+                  --build-url $BUILD_URL \
                   --is-pipeline true
         on_failure:
           put: slack-alert
@@ -397,6 +415,11 @@ jobs:
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
+
+                BUILD_URL="https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
+                echo $BUILD_URL
+
                 cloud-platform environment apply \
                   --skip-version-check \
                   --batch-apply-index $((3*${BATCHSIZE}))  \
@@ -405,6 +428,7 @@ jobs:
                   --cluster $PIPELINE_CLUSTER \
                   --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG \
+                  --build-url $BUILD_URL \
                   --is-pipeline true
         on_failure:
           put: slack-alert
@@ -454,6 +478,11 @@ jobs:
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
+
+                BUILD_URL="https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
+                echo $BUILD_URL
+
                 cloud-platform environment apply \
                   --skip-version-check \
                   --batch-apply-index $((4*${BATCHSIZE}))  \
@@ -462,6 +491,7 @@ jobs:
                   --cluster $PIPELINE_CLUSTER \
                   --clusterdir $PIPELINE_CLUSTER_DIR \
                   --kubecfg $KUBECONFIG \
+                  --build-url $BUILD_URL \
                   --is-pipeline true
         on_failure:
           put: slack-alert
@@ -484,6 +514,7 @@ jobs:
           path: cloud-platform-environments-live-pull-requests-merged
           status: pending
           comment: " Your PR is applying in the build: https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+
       - task: apply-namespace-changes
         timeout: 2h
         image: cloud-platform-cli
@@ -530,8 +561,7 @@ jobs:
                   --clusterdir $PIPELINE_CLUSTER_DIR \
                   --build-url $BUILD_URL\
                   --prNumber $PR \
-                  --kubecfg $KUBECONFIG \
-                  --is-pipeline true
+                  --kubecfg $KUBECONFIG
         on_success:
           put: cloud-platform-environments-live-pull-requests-merged
           params:
@@ -589,8 +619,7 @@ jobs:
                   --namespace $NAMESPACE \
                   --cluster $PIPELINE_CLUSTER \
                   --clusterdir $PIPELINE_CLUSTER_DIR \
-                  --kubecfg $KUBECONFIG \
-                  --is-pipeline true
+                  --kubecfg $KUBECONFIG
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
- pass the build url to the apply live pipelines so that if it fails on an rds version mismatch the failed pipeline URL can be included in the correcting PR