### PR TITLE
Plan push and pull to and from s3 

### DIFF
--- a/pipelines/manager/main/cordon-and-drain-nodes.yaml
+++ b/pipelines/manager/main/cordon-and-drain-nodes.yaml
@@ -3,7 +3,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -31,7 +31,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/custom-cluster.yaml
+++ b/pipelines/manager/main/custom-cluster.yaml
@@ -27,7 +27,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/delete-cluster.yaml
+++ b/pipelines/manager/main/delete-cluster.yaml
@@ -10,7 +10,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/divergence-live-2.yaml
+++ b/pipelines/manager/main/divergence-live-2.yaml
@@ -17,7 +17,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: slack-alert

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -17,7 +17,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: slack-alert

--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -26,7 +26,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -78,7 +78,7 @@ resources:
   type: registry-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.35.2"
+    tag: "1.36.0"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-environments-live-pull-requests-merged

--- a/pipelines/manager/main/infrastructure-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-live-2.yaml
@@ -98,7 +98,13 @@ jobs:
             args:
               - -c
               - |
-                cloud-platform terraform plan --workspace live-2 --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/
 
       - task: execute-core-plan
         image: cloud-platform-cli
@@ -117,7 +123,14 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live-2
                 )
-                cloud-platform terraform plan --workspace live-2 --skip-version-check
+
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/core/
 
       - task: execute-components-plan
         image: cloud-platform-cli
@@ -136,7 +149,13 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live-2
                 )
-                cloud-platform terraform plan --workspace live-2 --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/core/components/
     on_failure:
       put: pull-request
       params:
@@ -181,7 +200,13 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                cloud-platform terraform apply --workspace live-2 --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                aws s3 cp s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/$PLAN_FILENAME $PLAN_FILENAME
+
+                cloud-platform terraform apply --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
       - task: execute-core-apply
         image: cloud-platform-cli
@@ -204,7 +229,13 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                cloud-platform terraform apply --workspace live-2 --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                aws s3 cp s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/core/$PLAN_FILENAME $PLAN_FILENAME
+
+                cloud-platform terraform apply --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
       - task: execute-components-apply
         image: cloud-platform-cli
@@ -227,7 +258,13 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                cloud-platform terraform apply --workspace live-2 --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                aws s3 cp s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/core/components/$PLAN_FILENAME $PLAN_FILENAME
+
+                cloud-platform terraform apply --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
     on_failure:
       put: slack-alert

--- a/pipelines/manager/main/infrastructure-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-live-2.yaml
@@ -38,7 +38,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -98,7 +98,13 @@ jobs:
             args:
               - -c
               - |
-                cloud-platform terraform plan --workspace live --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/
 
       - task: execute-core-plan
         image: cloud-platform-cli
@@ -117,7 +123,13 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live
                 )
-                cloud-platform terraform plan --workspace live --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/
 
       - task: execute-components-plan
         image: cloud-platform-cli
@@ -136,7 +148,13 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live
                 )
-                cloud-platform terraform plan --workspace live --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/components/
     on_failure:
       put: pull-request
       params:
@@ -181,7 +199,13 @@ jobs:
                 # Get the latest from main
                 git pull origin main
 
-                cloud-platform terraform apply --workspace live --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/$PLAN_FILENAME $PLAN_FILENAME
+
+                cloud-platform terraform apply --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
       - task: execute-core-apply
         image: cloud-platform-cli
@@ -204,7 +228,13 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                cloud-platform terraform apply --workspace live --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/$PLAN_FILENAME $PLAN_FILENAME
+
+                cloud-platform terraform apply --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
       - task: execute-components-apply
         image: cloud-platform-cli
@@ -227,7 +257,13 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                cloud-platform terraform apply --workspace live --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/components/$PLAN_FILENAME $PLAN_FILENAME
+
+                cloud-platform terraform apply --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
     on_failure:
       put: slack-alert

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -38,7 +38,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -37,7 +37,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -97,7 +97,13 @@ jobs:
             args:
               - -c
               - |
-                cloud-platform terraform plan --workspace manager --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/
 
       - task: execute-core-plan
         image: cloud-platform-cli
@@ -116,8 +122,13 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name manager
                 )
-                cloud-platform terraform plan --workspace manager --skip-version-check
-                
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core
       - task: execute-components-plan
         image: cloud-platform-cli
         config:
@@ -135,7 +146,13 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name manager
                 )
-                cloud-platform terraform plan --workspace manager --skip-version-check
+                export PR=$(cat .git/resource/pr)
+
+                PLAN_FILENAME="plan-$PR.out"
+
+                cloud-platform terraform plan --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
+
+                aws s3 cp $PLAN_FILENAME s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/components/
     on_failure:
       put: pull-request
       params:
@@ -180,7 +197,13 @@ jobs:
                     # Get the latest from main 
                     git pull origin main
 
-                    cloud-platform terraform apply --workspace manager --skip-version-check
+                    export PR=$(cat .git/resource/pr)
+
+                    PLAN_FILENAME="plan-$PR.out"
+
+                    aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/$PLAN_FILENAME $PLAN_FILENAME
+
+                    cloud-platform terraform apply --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
           - task: execute-core-apply
             image: cloud-platform-cli
@@ -203,7 +226,13 @@ jobs:
                     # Get the latest from main
                     git pull origin main
 
-                    cloud-platform terraform apply --workspace manager --skip-version-check
+                    export PR=$(cat .git/resource/pr)
+
+                    PLAN_FILENAME="plan-$PR.out"
+
+                    aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/$PLAN_FILENAME $PLAN_FILENAME
+
+                    cloud-platform terraform apply --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
           - task: execute-components-apply
             image: cloud-platform-cli
@@ -226,8 +255,13 @@ jobs:
                     # Get the latest from main 
                     git pull origin main
 
-                    cloud-platform terraform apply --workspace manager --skip-version-check
+                    export PR=$(cat .git/resource/pr)
 
+                    PLAN_FILENAME="plan-$PR.out"
+
+                    aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/components/$PLAN_FILENAME $PLAN_FILENAME
+
+                    cloud-platform terraform apply --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
         on_failure:
           put: slack-alert
           params:

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -21,7 +21,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.35.2"
+      tag: "1.36.0"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: go-delete-snapshots-image


### PR DESCRIPTION
2/2

This PR pushes the plan file from the pipeline to our s3 bucket and respectively pulls the correct file from s3 to be used in terraform apply

- after plan cmd has ran, and plan files are created push the plan to s3
- before apply cmd has ran, pull the plan file from s3 and use that in the apply cmd