### PR TITLE
fix: 🐛 use commit hash instead of pr for id in plan file

### DIFF
--- a/pipelines/manager/main/infrastructure-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-live-2.yaml
@@ -98,9 +98,9 @@ jobs:
             args:
               - -c
               - |
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -124,9 +124,9 @@ jobs:
                   aws eks --region eu-west-2 update-kubeconfig --name live-2
                 )
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -149,9 +149,9 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live-2
                 )
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace live-2 --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -200,9 +200,9 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 aws s3 cp s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/$PLAN_FILENAME $PLAN_FILENAME
 
@@ -229,9 +229,9 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 aws s3 cp s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/core/$PLAN_FILENAME $PLAN_FILENAME
 
@@ -258,9 +258,9 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 aws s3 cp s3://cloud-platform-terraform-state/plan-files/live-2/aws-accounts/cloud-platform-aws/vpc/eks/core/components/$PLAN_FILENAME $PLAN_FILENAME
 

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -98,9 +98,9 @@ jobs:
             args:
               - -c
               - |
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -123,9 +123,9 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live
                 )
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -148,9 +148,9 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name live
                 )
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace live --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -199,9 +199,9 @@ jobs:
                 # Get the latest from main
                 git pull origin main
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/$PLAN_FILENAME $PLAN_FILENAME
 
@@ -228,9 +228,9 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/$PLAN_FILENAME $PLAN_FILENAME
 
@@ -257,9 +257,9 @@ jobs:
                 # Get the latest from main 
                 git pull origin main
 
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/components/$PLAN_FILENAME $PLAN_FILENAME
 

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -97,9 +97,9 @@ jobs:
             args:
               - -c
               - |
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -122,9 +122,9 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name manager
                 )
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -146,9 +146,9 @@ jobs:
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name manager
                 )
-                export PR=$(cat .git/resource/pr)
+                COMMIT_ID=$(git rev-parse --short HEAD)
 
-                PLAN_FILENAME="plan-$PR.out"
+                PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                 cloud-platform terraform plan --workspace manager --is-pipeline --plan-filename $PLAN_FILENAME --skip-version-check
 
@@ -197,9 +197,9 @@ jobs:
                     # Get the latest from main 
                     git pull origin main
 
-                    export PR=$(cat .git/resource/pr)
+                    COMMIT_ID=$(git rev-parse --short HEAD)
 
-                    PLAN_FILENAME="plan-$PR.out"
+                    PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                     aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/$PLAN_FILENAME $PLAN_FILENAME
 
@@ -226,9 +226,9 @@ jobs:
                     # Get the latest from main
                     git pull origin main
 
-                    export PR=$(cat .git/resource/pr)
+                    COMMIT_ID=$(git rev-parse --short HEAD)
 
-                    PLAN_FILENAME="plan-$PR.out"
+                    PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                     aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/$PLAN_FILENAME $PLAN_FILENAME
 
@@ -255,9 +255,9 @@ jobs:
                     # Get the latest from main 
                     git pull origin main
 
-                    export PR=$(cat .git/resource/pr)
+                    COMMIT_ID=$(git rev-parse --short HEAD)
 
-                    PLAN_FILENAME="plan-$PR.out"
+                    PLAN_FILENAME="plan-$COMMIT_ID.out"
 
                     aws s3 cp s3://cloud-platform-terraform-state/plan-files/manager/aws-accounts/cloud-platform-aws/vpc/eks/core/components/$PLAN_FILENAME $PLAN_FILENAME
 


### PR DESCRIPTION
We don't have access to the pr id everywhere so use the commit id, it makes more sense like this too.