### PR TITLE
fix: Remove unused resource repo

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -31,12 +31,6 @@ resources:
       tag: "1.5"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
-  - name: cloud-platform-environments-repo
-    type: git
-    source:
-      uri: https://github.com/ministryofjustice/cloud-platform-environments.git
-      branch: main
-      git_crypt_key: ((cloud-platform-environments-git-crypt.key))
   - name: tools-image
     type: docker-image
     source:


### PR DESCRIPTION
remove unused resource
```
error: invalid pipeline config:
invalid resources:
	resource 'cloud-platform-environments-repo' is not used
```
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/bootstrap/jobs/bootstrap-pipelines/builds/3944