### PR TITLE
feat: 🎸 add guardduty IAM permissions

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -754,6 +754,19 @@ data "aws_iam_policy_document" "global_account_policy" {
     ]
   }
 
+  statement {
+    actions = [
+      "guardduty:CreateMalwareProtectionPlan",
+      "guardduty:DeleteMalwareProtectionPlan",
+      "guardduty:UpdateMalwareProtectionPlan",
+      "guardduty:GetMalwareProtectionPlan"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
   /* End of permissions for concourse pipeline cloud-platform-aws account */
 }
 


### PR DESCRIPTION
This PR adds ability for concourse to manage guardduty malware protection plan resources