### PR TITLE
fix: Update Curl Command for Build_URL

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -525,7 +525,12 @@ jobs:
                   -H "Accept: application/vnd.github+json" \
                   -H "Authorization: Bearer $GITHUB_TOKEN" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
-                  "https://api.github.com/repos/ministryofjustice/cloud-platform-environments/issues/$PR/comments" | jq '.[].body' | awk '{print $9}' | tr -d '"')
+                  "https://api.github.com/repos/ministryofjustice/cloud-platform-environments/issues/$PR/comments" \
+                  | jq -r '.[]
+                  | select(.body | contains("Your PR is applying in the build:"))
+                  | .body' \
+                  | awk '{print $8}' \
+                  | tail -n 1)
 
                 echo $BUILD_URL
 


### PR DESCRIPTION
- The current variable `BUILD_URL` is as below:, there is an expected extra `created,` in the output, which caused the [notifyUserApplyFailed](https://github.com/ministryofjustice/cloud-platform-cli/blob/47b420a264ad550f579d74a3c840d15996d7ba93/pkg/environment/apply.go#L50) cannot work properly and cannot send message to Slack.
```
→ curl -L \
                  -H "Accept: application/vnd.github+json" \
                  -H "Authorization: Bearer $GITHUB_TOKEN" \
                  -H "X-GitHub-Api-Version: 2022-11-28" \
                  "https://api.github.com/repos/ministryofjustice/cloud-platform-environments/issues/$PR/comments" | jq '.[].body' | awk '{print $9}' | tr -d '"'
```
Output:
```
created,
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/9493
```


- This PR is to update the `BUILD_URL` curl command to:

  - Extract only the Concourse build link
  - Ensure that the extracted URL corresponds to the latest build (e.g., if builds are rerun, the output might include 100, 100.1, 100.2, etc., and the latest URL should be captured—100.2).


- Relates to https://github.com/ministryofjustice/cloud-platform/issues/6578
