### PR TITLE
chore: bump cli version

### DIFF
--- a/pipelines/manager/main/cordon-and-drain-nodes.yaml
+++ b/pipelines/manager/main/cordon-and-drain-nodes.yaml
@@ -3,7 +3,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/create-cluster.yaml
+++ b/pipelines/manager/main/create-cluster.yaml
@@ -31,7 +31,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/custom-cluster.yaml
+++ b/pipelines/manager/main/custom-cluster.yaml
@@ -27,7 +27,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/delete-cluster.yaml
+++ b/pipelines/manager/main/delete-cluster.yaml
@@ -10,7 +10,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/divergence-live-2.yaml
+++ b/pipelines/manager/main/divergence-live-2.yaml
@@ -17,7 +17,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: slack-alert

--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -17,7 +17,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: slack-alert

--- a/pipelines/manager/main/eks-create-test-destroy.yaml
+++ b/pipelines/manager/main/eks-create-test-destroy.yaml
@@ -26,7 +26,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
 

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -78,7 +78,7 @@ resources:
   type: registry-image
   source:
     repository: ministryofjustice/cloud-platform-cli
-    tag: "1.39.5"
+    tag: "1.39.6"
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: cloud-platform-environments-live-pull-requests-merged

--- a/pipelines/manager/main/infrastructure-live-2.yaml
+++ b/pipelines/manager/main/infrastructure-live-2.yaml
@@ -38,7 +38,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-live.yaml
+++ b/pipelines/manager/main/infrastructure-live.yaml
@@ -38,7 +38,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/infrastructure-manager.yaml
+++ b/pipelines/manager/main/infrastructure-manager.yaml
@@ -37,7 +37,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: pull-request

--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -21,7 +21,7 @@ resources:
     type: registry-image
     source:
       repository: ministryofjustice/cloud-platform-cli
-      tag: "1.39.5"
+      tag: "1.39.6"
       username: ((ministryofjustice-dockerhub.dockerhub_username))
       password: ((ministryofjustice-dockerhub.dockerhub_password))
   - name: go-delete-snapshots-image


### PR DESCRIPTION
- https://github.com/ministryofjustice/cloud-platform-cli/releases/tag/1.39.6