### PR TITLE
feat: 🎸 update hoodaw slack to include erroring namespaces

### DIFF
--- a/pipelines/manager/main/hoodaw.yaml
+++ b/pipelines/manager/main/hoodaw.yaml
@@ -1,3 +1,9 @@
+aws-credentials: &AWS_CREDENTIALS
+  AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
+  AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
+  AWS_REGION: eu-west-2
+environments-live-bucket: &ENVIRONMENTS_LIVE_BUCKET
+  ENVIRONMENTS_LIVE_S3_BUCKET: ((environments-live-reports-s3-bucket))
 slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
   channel: '#lower-priority-alarms'
   silent: true
@@ -28,6 +34,14 @@ resources:
     start: 10:00 AM
     stop: 5:00 PM
 
+- name: cloud-platform-cli
+  type: registry-image
+  source:
+    repository: ministryofjustice/cloud-platform-cli
+    tag: "1.39.8"
+    username: ((ministryofjustice-dockerhub.dockerhub_username))
+    password: ((ministryofjustice-dockerhub.dockerhub_password))
+
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -47,9 +61,10 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-        - get: every-24h-during-workweek
-          trigger: true
-        - get: dashboard-reporter-image
+          - get: every-24h-during-workweek
+            trigger: true
+          - get: dashboard-reporter-image
+          - get: cloud-platform-cli
       - task: generate-report
         image: dashboard-reporter-image
         config:
@@ -61,6 +76,31 @@ jobs:
             OUTPUT_FILE: report/action_items
           run:
             path: /app/report.rb
+      - task: report-erroring-namespaces
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          inputs:
+            - name: report
+          outputs:
+            - name: report
+          params:
+            <<:
+              [
+                *AWS_CREDENTIALS,
+                *ENVIRONMENTS_LIVE_BUCKET,
+              ] 
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                JSON_FILE="collated-errored-namespaces.json"
+                aws s3 cp s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/$JSON_FILE .
+
+                # The following is a temp workaround to add erroring namespaces to the Ruby hoodaw slack report:
+
+                sed -ie "/^terraform_modules/a erroring namespaces: $(jq '. | length' $JSON_FILE)" report/action_items
         on_success:
           put: slack-alert
           params:
@@ -71,6 +111,10 @@ jobs:
                 title: 'How out of date are we - action required:'
                 title_link: ((cloud-platform-reports-api-key.hostname))/dashboard
                 footer: ((cloud-platform-reports-api-key.hostname))
+              - color: "warning"
+                title: 'Erroring namespaces'
+                title_link: https://reports.cloud-platform.service.justice.gov.uk/erroring_namespaces
+                footer: https://reports.cloud-platform.service.justice.gov.uk/erroring_namespaces
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
a little bit of a hack to reformat the ruby dashboard report, we can integrate this into the base hoodaw repo when we've finished refactoring to go?

closes  ministryofjustice/cloud-platform#6461

![Screenshot 2025-02-20 at 16 58 37](https://github.com/user-attachments/assets/ddb38295-7896-4cd3-8f1d-281878c389c5)

