### PR TITLE
Update github-pr-resource image in environments-live pipeline to fix rate limit

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -113,7 +113,9 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: teliaoss/github-pr-resource
+  ## The image for this resource is customised from teliaoss/github-pr-resource to avoid hitting Github GraphQL API rate limits. https://github.com/ministryofjustice/cloud-platform/issues/5566
+    repository: ministryofjustice/cloud-platform-concourse-github-pr-resource
+    tag: v1.0.5
     username: ((ministryofjustice-dockerhub.dockerhub_username))
     password: ((ministryofjustice-dockerhub.dockerhub_password))
 - name: keyval


### PR DESCRIPTION
This PR replaces the [teliaoss/github-pr-resource](https://github.com/telia-oss/github-pr-resource) image in the `environments-live` pipeline with a customised image to [fix the API rate limit we've been hitting](https://github.com/ministryofjustice/cloud-platform/issues/5566). The image is used to resource check for newly merged PRs.

Previously when PR checks were ran against the environments repo, the check would hit GraphQL API limits causing the checks to timeout, as the repo has ~30k PRs. The new image now introduces logic to only check the last 300 PRs.

Source code for new image and changes from the original (which is forked from teliaoss/github-pr-resource) can be found [here](https://github.com/ministryofjustice/cloud-platform-concourse-github-pr-resource/pull/3)