### PR TITLE
fix: add group for process-rds-error-namespaces

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -144,6 +144,7 @@ groups:
     - destroy-deleted-namespaces
     - apply-live-cluster-user-roles
     - process-error-namespaces
+    - process-rds-error-namespaces
 
 jobs:
   - name: split-namespaces


### PR DESCRIPTION
- add `process-rds-error-namespaces` to group 