### PR TITLE
feat: run auto approve from folder

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -930,7 +930,7 @@ jobs:
                 PLAN_DIR="$(dirname "$PLAN_FILE")"
                 PLAN_NAME="$(basename "$PLAN_FILE")"
 
-                auto_approve.sh $PLAN_DIR $PLAN_NAME $PR
+                ./opa-auto-approve-policy/auto_approve.sh $PLAN_DIR $PLAN_NAME $PR
 
         on_failure:
             put: cloud-platform-environments-live-pull-requests


### PR DESCRIPTION
## 👀 Purpose

- Run `auto-approve.sh` from the `opa-auto-approve-policy` folder so we don't rely on the cli image to update the script