### PR TITLE
ci: add account and global-resources divergence pipelines

### DIFF
--- a/pipelines/manager/main/divergence.yaml
+++ b/pipelines/manager/main/divergence.yaml
@@ -48,11 +48,25 @@ groups:
       - divergence-eks-manager-components
       - divergence-eks-live-components
       - divergence-networking
+      - divergence-account-live
+      - divergence-global-resources
 
 common_params: &common_params
   AWS_ACCESS_KEY_ID: ((aws-creds.access-key-id))
   AWS_SECRET_ACCESS_KEY: ((aws-creds.secret-access-key))
   AWS_REGION: eu-west-2
+  AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
+  AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
+  AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
+
+aws_params_moj_cp: &aws_params_moj_cp
+  AWS_PROFILE: moj-cp
+
+terraform-shared: &TERRAFORM_SHARED
+  TF_VAR_github_owner: "ministryofjustice"
+  TF_VAR_github_token: ((github-actions-secrets-token.token))
+
+auth0: &AUTH0_CONF
   AUTH0_DOMAIN: "justice-cloud-platform.eu.auth0.com"
   AUTH0_CLIENT_ID: ((concourse-tf-auth0-credentials.client-id))
   AUTH0_CLIENT_SECRET: ((concourse-tf-auth0-credentials.client_secret))
@@ -314,3 +328,77 @@ jobs:
             attachments:
               - color: "danger"
                 <<: *SLACK_ATTACHMENTS_DEFAULTS
+  - name: divergence-account-live
+    serial: true
+    plan:
+      - in_parallel:
+          - get: every-4-hours
+            trigger: true
+          - get: cloud-platform-infrastructure-repo
+            trigger: false
+          - get: cloud-platform-cli
+            trigger: false
+      - task: check-divergence-account-live
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            <<: [*common_params, *aws_params_moj_cp, *TERRAFORM_SHARED]
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+              path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile moj-cp
+                aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile moj-cp
+                cd terraform/aws-accounts/cloud-platform-aws/account
+                cloud-platform terraform check-divergence --workspace default --skip-version-check
+          outputs:
+            - name: metadata
+        # on_failure:
+        #   put: slack-alert
+        #   params:
+        #     <<: *SLACK_NOTIFICATION_DEFAULTS
+        #     attachments:
+        #       - color: "danger"
+        #         <<: *SLACK_ATTACHMENTS_DEFAULTS
+  - name: divergence-global-resources
+    serial: true
+    plan:
+      - in_parallel:
+          - get: every-4-hours
+            trigger: true
+          - get: cloud-platform-infrastructure-repo
+            trigger: false
+          - get: cloud-platform-cli
+            trigger: false
+      - task: check-divergence-account-live
+        image: cloud-platform-cli
+        config:
+          platform: linux
+          params:
+            <<: [*common_params, *aws_params_moj_cp, *TERRAFORM_SHARED, *AUTH0_CONF]
+          inputs:
+            - name: cloud-platform-infrastructure-repo
+              path: ./
+          run:
+            path: /bin/sh
+            args:
+              - -c
+              - |
+                aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile moj-cp
+                aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile moj-cp
+                cd terraform/global-resources
+                cloud-platform terraform check-divergence --workspace default --skip-version-check
+          outputs:
+            - name: metadata
+        # on_failure:
+        #   put: slack-alert
+        #   params:
+        #     <<: *SLACK_NOTIFICATION_DEFAULTS
+        #     attachments:
+        #       - color: "danger"
+        #         <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
## 👀 Purpose

- Creates two new pipelines for `account` and `global-resources`.
- Slack notifications are disabled until the drift is fixed (if it can be).