### PR TITLE
feat: test the addition of a build-id step

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -232,6 +232,7 @@ jobs:
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
                 ERRORED_NAMESPACES_FILE="errored-namespaces-a.csv"
+                BUILD_ID_FILE="errored-namespaces-with-build-ids-a-${$BUILD_ID}.csv"
                 RDS_ERRORED_NAMESPACES_FILE="rds-errored-namespaces-a.csv"
 
                 touch $ERRORED_NAMESPACES_FILE $RDS_ERRORED_NAMESPACES_FILE
@@ -260,7 +261,6 @@ jobs:
                     ' >> $RDS_ERRORED_NAMESPACES_FILE \
                   )
                   if [[ -s "$ERRORED_NAMESPACES_FILE" ]]; then
-                    BUILD_ID_FILE="errored-namespaces-with-build-ids-a-${$BUILD_ID}.csv"
                     printf "namespace,build_id,error\n" > "$BUILD_ID_FILE"
 
                       awk -F',' -v build_id="$BUILD_ID" '{


### PR DESCRIPTION
## Purpose

- adds a build_id step to the current job in apply-live-a
- uses concourse's default [$BUILD_ID](https://concourse-ci.org/implementing-resource-types.html#resource-metadata) env var
- uploads the outcome to a separate file in the bucket

## What this does?
It tests appending a build_id to every failed namespace

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6832