### PR TITLE
fix: remove var in file name and write to the existing dir

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -267,7 +267,7 @@ jobs:
                         printf "%s,%s,%s\n", $1, build_id, substr($0, index($0, ",") + 1)
                       }' "$ERRORED_NAMESPACES_FILE" >> "$BUILD_ID_FILE"
 
-                  aws s3 cp $BUILD_ID_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/$BUILD_ID_FILE
+                  aws s3 cp $BUILD_ID_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/build-ids/$BUILD_ID_FILE
                   fi
                   aws s3 cp $ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/$ERRORED_NAMESPACES_FILE
                   aws s3 cp $RDS_ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/process-rds-error-namespaces/$RDS_ERRORED_NAMESPACES_FILE


### PR DESCRIPTION
## What's changed

- The filename is now static and doesn't include the build ID
