### PR TITLE
feat: add an independent task that runs parallel to ERRORED_NAMESPACE…

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -232,10 +232,10 @@ jobs:
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
                 ERRORED_NAMESPACES_FILE="errored-namespaces-a.csv"
-                BUILD_ID_FILE="errored-namespaces-with-build-ids-a-${$BUILD_ID}.csv"
+                BUILD_ERROR_FILE="build-errors-a.csv"
                 RDS_ERRORED_NAMESPACES_FILE="rds-errored-namespaces-a.csv"
 
-                touch $ERRORED_NAMESPACES_FILE $RDS_ERRORED_NAMESPACES_FILE
+                touch $ERRORED_NAMESPACES_FILE $RDS_ERRORED_NAMESPACES_FILE $BUILD_ERROR_FILE
 
                 cloud-platform environment apply \
                   --skip-version-check \
@@ -259,18 +259,17 @@ jobs:
                         show=0;
                       }
                     ' >> $RDS_ERRORED_NAMESPACES_FILE \
+                  ) >( \
+                      grep -E "Error in namespace:|Error:" \
+                      | awk -v build_id="$BUILD_ID" '
+                        /Error in namespace:/ {namespace=$NF}
+                        /Error:/ {print namespace "," build_id "," $0}
+                      ' >> $BUILD_ERROR_FILE \
                   )
-                  if [[ -s "$ERRORED_NAMESPACES_FILE" ]]; then
-                    printf "namespace,build_id,error\n" > "$BUILD_ID_FILE"
 
-                      awk -F',' -v build_id="$BUILD_ID" '{
-                        printf "%s,%s,%s\n", $1, build_id, substr($0, index($0, ",") + 1)
-                      }' "$ERRORED_NAMESPACES_FILE" >> "$BUILD_ID_FILE"
-
-                  aws s3 cp $BUILD_ID_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/build_ids/$BUILD_ID_FILE
-                  fi
                   aws s3 cp $ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/$ERRORED_NAMESPACES_FILE
                   aws s3 cp $RDS_ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/process-rds-error-namespaces/$RDS_ERRORED_NAMESPACES_FILE
+                  aws s3 cp $BUILD_ERROR_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/build_ids/$BUILD_ERROR_FILE
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
## What's Changed

- unlike the existing task that generates namespaces and their errors, this runs parallel to it and adds a build-id

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6832