### PR TITLE
fix: substitute  with

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -261,7 +261,7 @@ jobs:
                     ' >> $RDS_ERRORED_NAMESPACES_FILE \
                   ) >( \
                       grep -E "Error in namespace:|Error:" \
-                      | awk -v build_id="$BUILD_ID" '
+                      | awk -v build_id="$BUILD_NAME" '
                         /Error in namespace:/ {namespace=$NF}
                         /Error:/ {print namespace "," build_id "," $0}
                       ' >> $BUILD_ERROR_FILE \


### PR DESCRIPTION
Upon examining the build-errors-a.csv file downloaded from the s3 bucket, I noticed no build_ids were appended to all the errored namespaces. The aim is to get the build_id from the job itself i.e. apply-live-a. The [concourse doc](https://concourse-ci.org/implementing-resource-types.html#resource-metadata) explains the difference between $BUILD_ID and $BUILD_NAME, hence the change.