### PR TITLE
fix: pass pipeline env var artifact to the task

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -123,6 +123,11 @@ resource_types:
   type: docker-image
   source:
     repository: swce/keyval-resource
+- name: build-env-printer
+  type: docker-image
+  source:
+    repository: governmentpaas/olhtbr-metadata-resource
+    tag: latest
 
 
 groups:
@@ -201,6 +206,10 @@ jobs:
           trigger: true
           passed:
               - split-namespaces
+      - put: build-env
+        params: {}
+      - get: build-env
+        trigger: false
       - task: apply-environments
         timeout: 2h
         image: cloud-platform-cli
@@ -209,6 +218,7 @@ jobs:
           inputs:
             - name: cloud-platform-environments
             - name: keyval
+            - name: build-env
           params:
             <<:
               [
@@ -226,6 +236,12 @@ jobs:
             args:
               - -c
               - |
+                # --- build metadata from resource files ---
+                for f in ../build-env/*; do
+                  var_name=$(basename "$f")
+                  export $(printf '%s=%s' "$var_name" "$(cat "$f")")
+                done
+                # -------------------------------------------
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
@@ -261,9 +277,9 @@ jobs:
                     ' >> $RDS_ERRORED_NAMESPACES_FILE \
                   ) >( \
                       grep -E "Error in namespace:|Error:" \
-                      | awk -v build_id="$BUILD_ID" '
+                      | awk -v build_name="$build_name" '
                         /Error in namespace:/ {namespace=$NF}
-                        /Error:/ {print namespace "," build_id "," $0}
+                        /Error:/ {print namespace "," build_name "," $0}
                       ' >> $BUILD_ERROR_FILE \
                   )
 


### PR DESCRIPTION
## Purpose

- Capture each Concourse build number in the error CSV generated by apply-live-a, so we can trace every namespace error back to the exact Concourse build.


## What this does?

- Adds a tiny “metadata printer” resource (build-env-printer) and a build-env resource instance.
- Inserts a put / get pair that writes Concourse build metadata (BUILD_NAME, etc.) to the files.
- Exposes those files to the apply-environments task and exports them as env vars.
- Updates the awk that writes build-errors-a.csv to include the exported build_name.
- Leaves all other logic, outputs, and S3 uploads unchanged in the apply-live-a 


Output from a task in my test pipeline:

```
use-build-metadata
selected worker: ac28a4b81409
=== Build metadata from resource files ===
atc_external_url: http://localhost:8080
build_id: 2
build_job_name: hello-test-pipeline
build_name: 1
build_pipeline_name: hello-test-pipeline
build_team_name: main
```