### PR TITLE
fix: only export the BUILD_NAME and use build-name as res name

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -105,9 +105,6 @@ resources:
 - name: build-name
   type: build-env-printer
   source: {}
-- name: build-env
-  type: build-env-printer
-  source: {}
 
 resource_types:
 - name: slack-notification


### PR DESCRIPTION
## Purpose
Reduce noise in the build-error CSV by exporting only the Concourse build number (BUILD_NAME) and give the metadata resource a clearer name.

## What this does?

- Adds a new resource instance build-name in place of build-env
- Updates the apply-live-a job for put and get steps to use build-name
- Bash loop narrowed to only export $BUILD_NAME
- inputs also modified to use build-name instead of build-env


Instead of:

```
BUILD_ID | 35998421
-- | --
BUILD_NAME | 6513
BUILD_JOB_NAME | apply-live-a
BUILD_PIPELINE_NAME | environments-live
BUILD_TEAM_NAME | main
ATC_EXTERNAL_URL | https://concourse.cloud-platform.service.justice.gov.uk
```


the change will ensure the build output would only be:
`BUILD_NAME | 6513`