### PR TITLE
feat: add build name from pipeline metadata

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -387,7 +387,7 @@ jobs:
 
                   aws s3 cp $ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/$ERRORED_NAMESPACES_FILE
                   aws s3 cp $RDS_ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/process-rds-error-namespaces/$RDS_ERRORED_NAMESPACES_FILE
-                  aws s3 cp $BUILD_ERROR_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/build_ids/$BUILD_ERROR_FILE
+                  aws s3 cp $BUILD_ERROR_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/build_ids_b/$BUILD_ERROR_FILE
         on_failure:
           put: slack-alert
           params:

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -308,6 +308,10 @@ jobs:
           trigger: true
           passed:
               - split-namespaces
+      - put: build-name
+        params: {}
+      - get: build-name
+        trigger: false
       - task: apply-environments
         timeout: 2h
         image: cloud-platform-cli
@@ -316,6 +320,7 @@ jobs:
           inputs:
             - name: cloud-platform-environments
             - name: keyval
+            - name: build-name
           params:
             <<:
               [
@@ -333,15 +338,22 @@ jobs:
             args:
               - -c
               - |
+                # --- build metadata from resource files ---
+                for f in ../build-name/*; do
+                  var_name=$(basename "$f")
+                  export $(printf '%s=%s' "$var_name" "$(cat "$f")")
+                done
+                # -------------------------------------------
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (
                   aws eks --region eu-west-2 update-kubeconfig --name $TF_VAR_eks_cluster_name
                 )
                 export $(cat ../keyval/keyval.properties | grep BATCHSIZE )
                 ERRORED_NAMESPACES_FILE="errored-namespaces-b.csv"
+                BUILD_ERROR_FILE="build-errors-b.csv"
                 RDS_ERRORED_NAMESPACES_FILE="rds-errored-namespaces-b.csv"
 
-                touch $ERRORED_NAMESPACES_FILE $RDS_ERRORED_NAMESPACES_FILE
+                touch $ERRORED_NAMESPACES_FILE $RDS_ERRORED_NAMESPACES_FILE $BUILD_ERROR_FILE
 
                 cloud-platform environment apply \
                   --skip-version-check \
@@ -365,10 +377,17 @@ jobs:
                         show=0;
                       }
                     ' >> $RDS_ERRORED_NAMESPACES_FILE \
+                  ) >( \
+                      grep -E "Error in namespace:|Error:" \
+                      | awk -v build_name="$BUILD_NAME" '
+                        /Error in namespace:/ {namespace=$NF}
+                        /Error:/ {print namespace "," build_name "," $0}
+                      ' >> $BUILD_ERROR_FILE \
                   )
 
                   aws s3 cp $ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/$ERRORED_NAMESPACES_FILE
                   aws s3 cp $RDS_ERRORED_NAMESPACES_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/process-rds-error-namespaces/$RDS_ERRORED_NAMESPACES_FILE
+                  aws s3 cp $BUILD_ERROR_FILE s3://$ENVIRONMENTS_LIVE_S3_BUCKET/apply-live/build_ids/$BUILD_ERROR_FILE
         on_failure:
           put: slack-alert
           params:


### PR DESCRIPTION
## Purpose
Capture each Concourse build number in the error CSV generated by apply-live-b, so we can trace every namespace error back to the exact Concourse build.

##What this does?

- Adds a tiny “metadata printer” resource (build-env-printer) and a build-env resource instance.
- Inserts a put / get pair that writes Concourse build metadata (BUILD_NAME, etc.) to the files.
- Exposes those files to the apply-environments task and exports them as env vars.
- Updates the awk that writes build-errors-b.csv to include the exported build_name.
- Leaves all other logic, outputs, and S3 uploads unchanged in the apply-live-b

Relates to https://github.com/ministryofjustice/cloud-platform/issues/6832