### PR TITLE
Fix build name

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -280,7 +280,7 @@ jobs:
                     ' >> $RDS_ERRORED_NAMESPACES_FILE \
                   ) >( \
                       grep -E "Error in namespace:|Error:" \
-                      | awk -v build_name="$build_name" '
+                      | awk -v build_name="$BUILD_NAME" '
                         /Error in namespace:/ {namespace=$NF}
                         /Error:/ {print namespace "," build_name "," $0}
                       ' >> $BUILD_ERROR_FILE \

--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -240,7 +240,7 @@ jobs:
               - -c
               - |
                 # --- build metadata from resource files ---
-                for f in ../build-name/BUILD_NAME; do
+                for f in ../build-name/*; do
                   var_name=$(basename "$f")
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done


### PR DESCRIPTION
## Purpose
Ensures build_name="$BUILD_NAME" is what's rightly used to generate build-names in the s3 bucket and also generates all the pipeline metadata in the loop.

## What this des

- replaces build_name="$build_name" with build_name="$BUILD_NAME" 
- replaces /BUILD_NAME with /* in the loop as test showed /BUILD_NAME doesn't exist.