### PR TITLE
fix: export the BUILD_NAME var so it can be accessed and pushed to s3

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -244,6 +244,9 @@ jobs:
                   var_name=$(basename "$f")
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
+                # ensure BUILD_NAME is set for awk access
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                export BUILD_NAME
                 # -------------------------------------------
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (
@@ -343,6 +346,9 @@ jobs:
                   var_name=$(basename "$f")
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
+                # ensure BUILD_NAME is set for awk access
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                export BUILD_NAME
                 # -------------------------------------------
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (


### PR DESCRIPTION
## Purpose
Ensures the $BUILD_NAME var's value can be accessed by the script responsible for creating a column for the var and pushes it to s3.

## What this does/

- Sets the missing **BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')** for awk access