### PR TITLE
fix: add build name fallback to fix error

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -245,7 +245,7 @@ jobs:
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
                 # ensure BUILD_NAME is set for awk access
-                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')
                 export BUILD_NAME
                 # -------------------------------------------
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"


### PR DESCRIPTION
## Purpose
This adds a fallback to the script i.e. **build-name** to fix this issue in the pipeline which prevents the build name from being exported to the s3 bucket:
`cat: ../build-name/BUILD_NAME: No such file or directory`

## What's changed

- Replaces **BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')** with **BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')**