### PR TITLE
fix: add build name fallback to fix error in jobs b to e

### DIFF
--- a/pipelines/manager/main/environments-live.yaml
+++ b/pipelines/manager/main/environments-live.yaml
@@ -347,7 +347,7 @@ jobs:
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
                 # ensure BUILD_NAME is set for awk access
-                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')
                 export BUILD_NAME
                 # -------------------------------------------
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
@@ -449,7 +449,7 @@ jobs:
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
                 # ensure BUILD_NAME is set for awk access
-                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')
                 export BUILD_NAME
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (
@@ -550,7 +550,7 @@ jobs:
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
                 # ensure BUILD_NAME is set for awk access
-                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')
                 export BUILD_NAME
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (
@@ -651,7 +651,7 @@ jobs:
                   export $(printf '%s=%s' "$var_name" "$(cat "$f")")
                 done
                 # ensure BUILD_NAME is set for awk access
-                BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')
+                BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')
                 export BUILD_NAME
                 mkdir -p "${TF_PLUGIN_CACHE_DIR}"
                 (


### PR DESCRIPTION
## Purpose
Having confirmed that changes made in [this pr](https://github.com/ministryofjustice/cloud-platform-terraform-concourse/pull/531) successfully ensured the build_id column in the s3 bucket's file in job-a has now been properly populated, this PR will do the same for apply-live- b to e.

## What's changed

- Replaces **BUILD_NAME=$(cat ../build-name/BUILD_NAME | tr -d '\n')** with **BUILD_NAME=$(cat ../build-name/BUILD_NAME 2>/dev/null || cat ../build-name/build_name 2>/dev/null | tr -d '\n')** across tasks in jobs `a` to `e` in the pipeline.