### PR TITLE
adding permission for Concourse IAM User to ListPolicyTags

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -41,7 +41,8 @@ data "aws_iam_policy_document" "policy" {
       "iam:GetPolicyVersion",
       "iam:DeleteUserPermissionsBoundary",
       "iam:Tag*",
-      "iam:Untag*"
+      "iam:Untag*",
+      "iam:ListPolicyTags"
     ]
 
     resources = [


### PR DESCRIPTION
Fixing this error to allow Concourse user to list IAM policy tags:

Error: listing tags for IAM (Identity & Access Management) Policy (arn:aws:iam::<REDACTED>:policy/cloud-platform/s3/cloud-platform-s3-25509e67e1aa7dafa506c9cff56b12de): listing tags for resource (arn:aws:iam::<REDACTED>:policy/cloud-platform/s3/cloud-platform-s3-25509e67e1aa7dafa506c9cff56b12de): operation error IAM: ListPolicyTags, https response error StatusCode: 403, RequestID: b1be7dd2-c4c5-4acb-bd2b-216ed840e676, api error AccessDenied: User: arn:aws:iam::<REDACTED>:user/cloud-platform/manager-concourse is not authorized to perform: iam:ListPolicyTags on resource: policy arn:aws:iam::<REDACTED>:policy/cloud-platform/s3/cloud-platform-s3-25509e67e1aa7dafa506c9cff56b12de because no identity-based policy allows the iam:ListPolicyTags action