### PR TITLE
chore: 🤖 bump irsa module version to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module "concourse" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_irsa"></a> [irsa](#module\_irsa) | github.com/ministryofjustice/cloud-platform-terraform-irsa | 2.0.0 |
+| <a name="module_irsa"></a> [irsa](#module\_irsa) | github.com/ministryofjustice/cloud-platform-terraform-irsa | 2.1.0 |
 
 ## Resources
 

--- a/hoodaw_irsa.tf
+++ b/hoodaw_irsa.tf
@@ -1,5 +1,5 @@
 module "irsa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.1.0"
   count  = var.hoodaw_irsa_enabled ? 1 : 0
 
   # EKS configuration


### PR DESCRIPTION
[release](https://github.com/ministryofjustice/cloud-platform-terraform-irsa/releases/tag/2.1.0)