### PR TITLE
perf: ⚡️ flip log level to info

### DIFF
--- a/templates/values.yaml
+++ b/templates/values.yaml
@@ -34,7 +34,7 @@ concourse:
      - SetTeam
 
     # Setting debug
-    logLevel: debug
+    logLevel: info
 
     ## Maximum days to retain build logs, 0 means not specified. Will override values configured in jobs.
     ##
@@ -108,7 +108,7 @@ web:
 
   env:
     - name: CONCOURSE_LOG_LEVEL
-      value: "debug"
+      value: "info"
 
   ## Configure additional volumes for the
   ## web container(s).


### PR DESCRIPTION
## Purpose

No need to have logging at `debug` level, flipping to `info`