### PR TITLE
chore: 🤖 reduce oldest node recycle job from 6 to 4

### DIFF
--- a/pipelines/manager/main/maintenance.yaml
+++ b/pipelines/manager/main/maintenance.yaml
@@ -35,10 +35,10 @@ resources:
     type: slack-notification
     source:
       url: https://hooks.slack.com/services/((slack-hook-id))
-  - name: every-30m-between-midnight-3am
+  - name: every-45m-between-midnight-3am
     type: time
     source:
-      interval: 30m
+      interval: 45m
       start: 00:00 AM
       stop: 03:00 AM
   - name: every-hour
@@ -90,7 +90,7 @@ jobs:
     serial: true
     plan:
       - in_parallel:
-          - get: every-30m-between-midnight-3am
+          - get: every-45m-between-midnight-3am
             trigger: true
           - get: cloud-platform-cli
       - task: recycle-oldest-node


### PR DESCRIPTION
30 min space is leading to occasional  node recycle reporting failures. looking at worker node age in live we're back in a good place so reducing the recycle frequency for now.