### PR TITLE
ci: remove delay in parallel command

### DIFF
--- a/pipelines/manager/main/cordon-and-drain-nodes.yaml
+++ b/pipelines/manager/main/cordon-and-drain-nodes.yaml
@@ -122,5 +122,5 @@ jobs:
                 clean_stuck_pods &
 
                 export -f drain_and_remove_node
-                kubectl get nodes -l eks.amazonaws.com/nodegroup=$NODE_GROUP_TO_DRAIN --sort-by=metadata.creationTimestamp --no-headers | awk '{print $1}' | parallel -j1 --keep-order --delay 300 --will-cite drain_and_remove_node $1
+                kubectl get nodes -l eks.amazonaws.com/nodegroup=$NODE_GROUP_TO_DRAIN --sort-by=metadata.creationTimestamp --no-headers | awk '{print $1}' | parallel -j1 --keep-order --will-cite drain_and_remove_node $1
 


### PR DESCRIPTION
## Purpose

- Each cordon and drain is hardcoded to take 570 seconds this removes one of the delays bringing it down to hopefully 270 seconds.