### PR TITLE
adding ListRoleTags permissions

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -219,6 +219,7 @@ data "aws_iam_policy_document" "policy" {
       "iam:ListInstanceProfilesForRole",
       "iam:DeleteRolePolicy",
       "iam:DeleteRole",
+      "iam:ListRoleTags",
     ]
 
     resources = [


### PR DESCRIPTION
This enables the concourse user to be able to `ListRoleTags` action on `role/cloud-platform-*` resources.

Resolves the issue highlighted in this [Slack thread](https://mojdt.slack.com/archives/C57UPMZLY/p1778591319695389)