### PR TITLE
feat: add new secret for dockerhub credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ module "concourse" {
 | [kubernetes_resource_quota.concourse](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/resource_quota) | resource |
 | [kubernetes_resource_quota.concourse_main](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/resource_quota) | resource |
 | [kubernetes_role_binding.concourse_web](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
-| [kubernetes_secret.chainguard_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.cloud_platform_infra_pr_git_access_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.concourse_aws_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.concourse_basic_auth_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
@@ -115,6 +114,7 @@ module "concourse" {
 | [kubernetes_secret.concourse_main_update_authorized_keys_github_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.concourse_tf_auth0_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.dockerhub_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.dockerhub_image_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.environnments_live_reports_s3_bucket](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.github_actions_secrets_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.github_cloud_platform_concourse_bot_app_id](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ module "concourse" {
 | [kubernetes_resource_quota.concourse](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/resource_quota) | resource |
 | [kubernetes_resource_quota.concourse_main](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/resource_quota) | resource |
 | [kubernetes_role_binding.concourse_web](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+| [kubernetes_secret.chainguard_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.cloud_platform_infra_pr_git_access_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.concourse_aws_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.concourse_basic_auth_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
@@ -134,6 +135,7 @@ module "concourse" {
 | [aws_iam_policy_document.global_account_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+| [aws_ssm_parameter.dockerhub_registry_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,3 @@
+data "aws_ssm_parameter" "dockerhub_registry_credentials" {
+  name = "/cloud-platform/infrastructure/account/dockerhub_credentials"
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -150,7 +150,7 @@ resource "kubernetes_secret" "kraken_github_token" {
   }
 }
 
-resource "kubernetes_secret" "chainguard_credentials" {
+resource "kubernetes_secret" "dockerhub_image_pull_secret" {
   metadata {
     name      = "dockerhub-image-pull-secret"
     namespace = kubernetes_namespace.concourse_main.id

--- a/secrets.tf
+++ b/secrets.tf
@@ -149,3 +149,20 @@ resource "kubernetes_secret" "kraken_github_token" {
         value = var.kraken_github_token
   }
 }
+
+resource "kubernetes_secret" "chainguard_credentials" {
+  metadata {
+    name      = "dockerhub-image-pull-secret"
+    namespace = kubernetes_namespace.concourse_main.id
+  }
+
+  data = {
+    ".dockerconfigjson" = data.aws_ssm_parameter.dockerhub_registry_credentials.value
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  depends_on = [
+    kubernetes_namespace.concourse_main.id
+  ]
+}


### PR DESCRIPTION
## Purpose

- Relates to https://github.com/ministryofjustice/cloud-platform-security-issues/issues/148
- Part of a 2 part release, this creates the secret ready for usage by the helm chart